### PR TITLE
Added link for discord community

### DIFF
--- a/projects/developer-cheatsheet/public/js/mapboxItems.js
+++ b/projects/developer-cheatsheet/public/js/mapboxItems.js
@@ -398,6 +398,7 @@ export default [
     category: 'tools-and-resources',
     title: 'MapboxDevs Discord',
     subTitle: 'Chat, get help, find friends',
+    link: 'https://discord.gg/UshjQYyDFw',
     icon: 'discord'
   },
   {


### PR DESCRIPTION
This PR adds a missing link for the Mapbox developer Discord.

The change has been deployed via the internal deployment scripts.