### PR TITLE
Add iOS, Android & Flutter to copiable snippets

### DIFF
--- a/projects/demo-components/src/fullscreen-map-layout.jsx
+++ b/projects/demo-components/src/fullscreen-map-layout.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import Header from './header'
 
-const FullscreenMapLayout = ({ headerProps, mapComponent, children }) => {
+const FullscreenMapLayout = ({ headerProps, mapComponent, children, sidebarSize = 'w320' }) => {
   return (
     <div
       id='container'
@@ -10,7 +10,7 @@ const FullscreenMapLayout = ({ headerProps, mapComponent, children }) => {
       <div className='flex-child-grow relative flex flex--column'>
         {mapComponent}
         {/* medium+ sidebar */}
-        <div className='absolute left mx6 my6 px6 py6 top-ml w360 none block-ml z4 bottom mb30 hmax-full'>
+        <div className={`${sidebarSize} absolute left mx6 my6 px6 py6 top-ml none block-ml z4 bottom mb30 hmax-full`}>
           <div className='bg-white h-auto-ml hmax-full px12 py12 round-ml scroll-auto shadow-darken25 shadow-none-ml viewport-third overflow-scroll'>
             {children}
           </div>

--- a/projects/location-helper/src/Android.jsx
+++ b/projects/location-helper/src/Android.jsx
@@ -1,25 +1,8 @@
-import React, { useState, useEffect } from 'react'
-import PropTypes from 'prop-types'
-import TableRow from "./TableRow"
+import React from 'react'
+import BasePlatform from './BasePlatform'
 import { format } from './utils'
 
-const Android = ({
-    center,  
-    displayZoom, 
-    displayBearing, 
-    displayPitch, 
-    bounds, 
-    bbox,
-    zxy }) => {
-
-    const [displayBbox, setDisplayBbox ] = useState('use the polygon button to draw a bounding box')
-
-    useEffect(()=> {
-        if(bbox) {
-            const bounding = formatBoundingBox(bbox);
-            setDisplayBbox(bounding)
-        }
-    }, [bbox])
+const Android = (props) => {
     
     function processCenter(centerObj) {
         return `Point.fromLngLat(${format(centerObj.lng, 5)}, ${format(centerObj.lat, 5)})`
@@ -43,36 +26,7 @@ const Android = ({
 )`)
     }
 
-    return (
-
-        <div className='overflow-x-auto relative'>
-          <TableRow label='center' value={processCenter(center)} />
-          <TableRow label='zoom' value={displayZoom} />
-          <TableRow label='bearing' value={displayBearing} />
-          <TableRow label='pitch' value={displayPitch} />
-          <TableRow
-            label='viewport bounds'
-            value={formatBoundsArray(bounds)}
-            noBorder
-          />
-          <TableRow
-            label='user-drawn bounding box'
-            value={displayBbox}
-            noBorder
-          />
-          <TableRow label='z/x/y tile' value={zxy} noBorder />
-        </div>
-    )
+    return <BasePlatform {...props} formatCenter={processCenter} formatBounds={formatBoundsArray} formatBbox={formatBoundingBox} />
 }
 
 export default Android
-
-Android.propTypes = {
-    center: PropTypes.object,
-    displayZoom: PropTypes.string,
-    displayBearing: PropTypes.string,
-    displayPitch: PropTypes.string,
-    bounds: PropTypes.object, 
-    displayBbox: PropTypes.any,
-    zxy: PropTypes.any
-}

--- a/projects/location-helper/src/Android.jsx
+++ b/projects/location-helper/src/Android.jsx
@@ -1,24 +1,58 @@
+import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import TableRow from "./TableRow"
+import { format } from './utils'
 
 const Android = ({
-    displayCenterArray,  
+    center,  
     displayZoom, 
     displayBearing, 
     displayPitch, 
-    displayBoundsArray, 
-    displayBbox,
+    bounds, 
+    bbox,
     zxy }) => {
+
+    const [displayBbox, setDisplayBbox ] = useState('use the polygon button to draw a bounding box')
+
+    useEffect(()=> {
+        if(bbox) {
+            const bounding = formatBoundingBox(bbox);
+            setDisplayBbox(bounding)
+        }
+    }, [bbox])
+    
+    function processCenter(centerObj) {
+        return `Point.fromLngLat(${format(centerObj.lng, 5)}, ${format(centerObj.lat, 5)})`
+    }
+
+    function formatBoundsArray(bounds) {
+        return (
+`CoordinateBounds(
+    Point.fromLngLat(${format(bounds._sw.lng, 5)} ${format(bounds._sw.lat, 5)}),
+    Point.fromLngLat(${format(bounds._ne.lng, 5)}, ${format(bounds._ne.lat, 5)}),
+    false
+)`)    
+    }
+
+    function formatBoundingBox(bbox) {
+        return (
+`CoordinateBounds(
+    Point.fromLngLat( ${format(bbox[0], 5)} ${format(bbox[1], 5)}),
+    Point.fromLngLat(${format(bbox[2], 5)}, ${format(bbox[3], 5)}),
+    false
+)`)
+    }
+
     return (
 
         <div className='overflow-x-auto relative'>
-          <TableRow label='center' value={displayCenterArray} />
+          <TableRow label='center' value={processCenter(center)} />
           <TableRow label='zoom' value={displayZoom} />
           <TableRow label='bearing' value={displayBearing} />
           <TableRow label='pitch' value={displayPitch} />
           <TableRow
             label='viewport bounds'
-            value={displayBoundsArray}
+            value={formatBoundsArray(bounds)}
             noBorder
           />
           <TableRow
@@ -34,12 +68,11 @@ const Android = ({
 export default Android
 
 Android.propTypes = {
-    displayCenterArray: PropTypes.array,
-    displayCenterObject: PropTypes.object,
-    displayZoom: PropTypes.number,
-    displayBearing: PropTypes.number,
-    displayPitch: PropTypes.number,
-    displayBoundsArray: PropTypes.array, 
-    displayBbox: PropTypes.array,
+    center: PropTypes.object,
+    displayZoom: PropTypes.string,
+    displayBearing: PropTypes.string,
+    displayPitch: PropTypes.string,
+    bounds: PropTypes.object, 
+    displayBbox: PropTypes.any,
     zxy: PropTypes.any
 }

--- a/projects/location-helper/src/Android.jsx
+++ b/projects/location-helper/src/Android.jsx
@@ -28,18 +28,18 @@ const Android = ({
     function formatBoundsArray(bounds) {
         return (
 `CoordinateBounds(
-    Point.fromLngLat(${format(bounds._sw.lng, 5)} ${format(bounds._sw.lat, 5)}),
-    Point.fromLngLat(${format(bounds._ne.lng, 5)}, ${format(bounds._ne.lat, 5)}),
-    false
+  Point.fromLngLat(${format(bounds._sw.lng, 5)} ${format(bounds._sw.lat, 5)}),
+  Point.fromLngLat(${format(bounds._ne.lng, 5)}, ${format(bounds._ne.lat, 5)}),
+  false
 )`)    
     }
 
     function formatBoundingBox(bbox) {
         return (
 `CoordinateBounds(
-    Point.fromLngLat( ${format(bbox[0], 5)} ${format(bbox[1], 5)}),
-    Point.fromLngLat(${format(bbox[2], 5)}, ${format(bbox[3], 5)}),
-    false
+  Point.fromLngLat( ${format(bbox[0], 5)} ${format(bbox[1], 5)}),
+  Point.fromLngLat(${format(bbox[2], 5)}, ${format(bbox[3], 5)}),
+  false
 )`)
     }
 

--- a/projects/location-helper/src/Android.jsx
+++ b/projects/location-helper/src/Android.jsx
@@ -1,0 +1,45 @@
+import PropTypes from 'prop-types'
+import TableRow from "./TableRow"
+
+const Android = ({
+    displayCenterArray,  
+    displayZoom, 
+    displayBearing, 
+    displayPitch, 
+    displayBoundsArray, 
+    displayBbox,
+    zxy }) => {
+    return (
+
+        <div className='overflow-x-auto relative'>
+          <TableRow label='center' value={displayCenterArray} />
+          <TableRow label='zoom' value={displayZoom} />
+          <TableRow label='bearing' value={displayBearing} />
+          <TableRow label='pitch' value={displayPitch} />
+          <TableRow
+            label='viewport bounds'
+            value={displayBoundsArray}
+            noBorder
+          />
+          <TableRow
+            label='user-drawn bounding box'
+            value={displayBbox}
+            noBorder
+          />
+          <TableRow label='z/x/y tile' value={zxy} noBorder />
+        </div>
+    )
+}
+
+export default Android
+
+Android.propTypes = {
+    displayCenterArray: PropTypes.array,
+    displayCenterObject: PropTypes.object,
+    displayZoom: PropTypes.number,
+    displayBearing: PropTypes.number,
+    displayPitch: PropTypes.number,
+    displayBoundsArray: PropTypes.array, 
+    displayBbox: PropTypes.array,
+    zxy: PropTypes.any
+}

--- a/projects/location-helper/src/App.css
+++ b/projects/location-helper/src/App.css
@@ -7,3 +7,7 @@
 .copiable-container:hover [data-testid='copy-button'] {
   visibility: visible;
 }
+
+/* pre {
+  white-space: pre;
+} */

--- a/projects/location-helper/src/App.css
+++ b/projects/location-helper/src/App.css
@@ -7,7 +7,3 @@
 .copiable-container:hover [data-testid='copy-button'] {
   visibility: visible;
 }
-
-/* pre {
-  white-space: pre;
-} */

--- a/projects/location-helper/src/App.jsx
+++ b/projects/location-helper/src/App.jsx
@@ -313,7 +313,9 @@ function App() {
           overlapBorder={true}
           themeTabsContainer={"mb12 border-b border--blue"}
           items={[
-            { id: 'web', label: 'Web', content: <Web  
+            { id: 'web', 
+              label: 'Web', 
+              content: <Web  
                 center={center}
                 displayZoom={displayZoom} 
                 displayBearing={displayBearing}
@@ -323,7 +325,9 @@ function App() {
                 zxy={zxy}
                 /> 
             },
-            { id: 'ios', label: 'iOS', content: <Ios
+            { id: 'ios', 
+              label: 'iOS', 
+              content: <Ios
                 center={center}
                 displayZoom={displayZoom} 
                 displayBearing={displayBearing}
@@ -331,8 +335,11 @@ function App() {
                 bounds={bounds}
                 bbox={bbox}
                 zxy={zxy}
-              /> },
-            { id: 'android', label: 'Android', content: <Android 
+              /> 
+            },
+            { id: 'android', 
+              label: 'Android', 
+              content: <Android 
                 center={center}
                 displayZoom={displayZoom} 
                 displayBearing={displayBearing}
@@ -340,16 +347,20 @@ function App() {
                 bounds={bounds}                
                 bbox={bbox}
                 zxy={zxy}
-                />  },
-            { id: 'flutter', label: 'Flutter', content: <Flutter 
-              center={center}
-              displayZoom={displayZoom} 
-              displayBearing={displayBearing}
-              displayPitch={displayPitch}
-              bounds={bounds}                
-              bbox={bbox}
-              zxy={zxy}
-              />  },
+                />  
+            },
+            { id: 'flutter', 
+              label: 'Flutter', 
+              content: <Flutter 
+                center={center}
+                displayZoom={displayZoom} 
+                displayBearing={displayBearing}
+                displayPitch={displayPitch}
+                bounds={bounds}                
+                bbox={bbox}
+                zxy={zxy}
+                />  
+            },
           ]}
         />
 

--- a/projects/location-helper/src/App.jsx
+++ b/projects/location-helper/src/App.jsx
@@ -240,6 +240,8 @@ function App() {
           githubLink:
             'https://github.com/mapbox/public-tools-and-demos/tree/main/projects/location-helper'
         }}
+        /* pass in sidebar width via assembly class */
+        sidebarSize={'w-1/3'}
         mapComponent={
           <Map
             center={center}
@@ -284,15 +286,11 @@ function App() {
         <div className='mb12 txt-s'>
           The map&apos;s current center point, zoom level, rotation angle, and
           pitch angle are displayed below. You can use these values to set the
-          camera position in{' '}
-          <ExternalLink to='https://docs.mapbox.com/mapbox-gl-js'>
-            Mapbox GL JS
-          </ExternalLink>{' '}
-          or the{' '}
-          <ExternalLink to='https://www.mapbox.com/mobile-maps-sdk'>
-            Mapbox Mobile SDKs
-          </ExternalLink>
-          .
+          camera position in
+          <ExternalLink to='https://docs.mapbox.com/mapbox-gl-js'> Mapbox GL JS </ExternalLink>
+          or the
+          <ExternalLink to='https://docs.mapbox.com/ios/maps/guides'> iOS </ExternalLink> or the 
+          <ExternalLink to='https://docs.mapbox.com/android/maps/guides'> Android </ExternalLink>mobile SDK's.
         </div>
 
         <Tabs

--- a/projects/location-helper/src/App.jsx
+++ b/projects/location-helper/src/App.jsx
@@ -6,12 +6,16 @@ import {
   quadkeyToTile,
   tileToBBOX
 } from '@mapbox/tilebelt'
+import Web from './Web'
+import Ios from './Ios'
+import Android from './Android'
 import bboxPolygon from '@turf/bbox-polygon'
 import { ExternalLink, FullscreenMapLayout, Map } from 'mapbox-demo-components'
-import Copiable from '@mapbox/mr-ui/copiable'
+import Tabs from '@mapbox/mr-ui/tabs'
 import MapboxDraw from '@mapbox/mapbox-gl-draw'
 import DrawRectangle from 'mapbox-gl-draw-rectangle-mode'
 import turfBbox from '@turf/bbox'
+import { format } from './utils'
 
 import '@mapbox/mbx-assembly/dist/assembly.js'
 import MapboxGLButtonControl from './MapboxGLButtonControl'
@@ -36,34 +40,6 @@ const INITIAL_BOUNDS = {
   }
 }
 
-const format = (d, n) => {
-  return d.toFixed(n).replace(/[.,]00$/, '')
-}
-
-const TableRow = ({ label, value, noBorder }) => (
-  <div
-    className={`flex flex--center-cross py3 ${
-      !noBorder && 'border-b border--gray-light'
-    }`}
-  >
-    <div
-      scope='row'
-      className='w120 align-r py3 txt-s txt-bold flex-child-no-shrink'
-    >
-      {label}
-    </div>
-    <div className='txt-mono txt-ms pl12 flex-child-grow copiable-container'>
-      <Copiable value={value} />
-    </div>
-  </div>
-)
-
-TableRow.propTypes = {
-  label: PropTypes.any,
-  noBorder: PropTypes.any,
-  value: PropTypes.any
-}
-
 function App() {
   const [center, setCenter] = useState(INITIAL_CENTER)
   const [zoom, setZoom] = useState(INITIAL_ZOOM)
@@ -74,6 +50,7 @@ function App() {
   const [quadkey, setQuadkey] = useState(null)
   const [bbox, setBbox] = useState(null)
   const drawRef = useRef()
+  const [activeTab, setActiveTab] = useState('web')
 
   const startDrawingBbox = () => {
     if (
@@ -248,33 +225,13 @@ function App() {
     })
   }
 
-  const displayCenterArray = `[${format(center.lng, 5)}, ${format(
-    center.lat,
-    5
-  )}]`
-  const displayCenterObject = `{lng: ${format(center.lng, 5)}, lat: ${format(
-    center.lat,
-    5
-  )}}`
-
   const displayZoom = format(zoom, 2)
   const displayBearing = format(bearing, 2)
   const displayPitch = format(pitch, 2)
-
-  const displayBoundsArray = `[[${format(bounds._sw.lng, 5)}, ${format(
-    bounds._sw.lat,
-    5
-  )}], [${format(bounds._ne.lng, 5)}, ${format(bounds._ne.lat, 5)}]]`
+  
   const tile = quadkey ? quadkeyToTile(quadkey) : []
   const zxy = quadkey ? `${tile[2]}/${tile[0]}/${tile[1]}` : ''
 
-  let displayBbox = 'use the polygon button to draw a bounding box'
-  if (bbox) {
-    displayBbox = `[[${format(bbox[0], 5)}, ${format(bbox[1], 5)}],[${format(
-      bbox[2],
-      5
-    )}, ${format(bbox[3], 5)}]]`
-  }
   return (
     <div className='App h-viewport-full'>
       <FullscreenMapLayout
@@ -337,24 +294,43 @@ function App() {
           </ExternalLink>
           .
         </div>
-        <div className='overflow-x-auto relative'>
-          <TableRow label='center (array)' value={displayCenterArray} />
-          <TableRow label='center (object)' value={displayCenterObject} />
-          <TableRow label='zoom' value={displayZoom} />
-          <TableRow label='bearing' value={displayBearing} />
-          <TableRow label='pitch' value={displayPitch} />
-          <TableRow
-            label='viewport bounds'
-            value={displayBoundsArray}
-            noBorder
-          />
-          <TableRow
-            label='user-drawn bounding box'
-            value={displayBbox}
-            noBorder
-          />
-          <TableRow label='z/x/y tile' value={zxy} noBorder />
-        </div>
+
+        <Tabs
+          onChange={(id) => setActiveTab(id)}
+          active={activeTab}
+          themeTabsContainer="mb12"
+          items={[
+            { id: 'web', label: 'Web', content: <Web  
+                center={center}
+                displayZoom={displayZoom} 
+                displayBearing={displayBearing}
+                displayPitch={displayPitch}
+                bounds={bounds}
+                bbox={bbox}
+                zxy={zxy}
+                /> 
+            },
+            { id: 'ios', label: 'iOS', content: <Ios
+                center={center}
+                displayZoom={displayZoom} 
+                displayBearing={displayBearing}
+                displayPitch={displayPitch}
+                bounds={bounds}
+                bbox={bbox}
+                zxy={zxy}
+              /> },
+            { id: 'android', label: 'Android', content: <Android 
+                center={center}
+                displayZoom={displayZoom} 
+                displayBearing={displayBearing}
+                displayPitch={displayPitch}
+                bounds={bounds}                
+                bbox={bbox}
+                zxy={zxy}
+                />  },
+          ]}
+        />
+
       </FullscreenMapLayout>
     </div>
   )

--- a/projects/location-helper/src/App.jsx
+++ b/projects/location-helper/src/App.jsx
@@ -296,7 +296,10 @@ function App() {
         <Tabs
           onChange={(id) => setActiveTab(id)}
           active={activeTab}
-          themeTabsContainer="mb12"
+          activeColor={'blue'}
+          hoverColor={'gray-dark'}
+          overlapBorder={true}
+          themeTabsContainer={"mb12 border-b border--blue"}
           items={[
             { id: 'web', label: 'Web', content: <Web  
                 center={center}

--- a/projects/location-helper/src/App.jsx
+++ b/projects/location-helper/src/App.jsx
@@ -9,6 +9,7 @@ import {
 import Web from './Web'
 import Ios from './Ios'
 import Android from './Android'
+import Flutter from './Futter'
 import bboxPolygon from '@turf/bbox-polygon'
 import { ExternalLink, FullscreenMapLayout, Map } from 'mapbox-demo-components'
 import Tabs from '@mapbox/mr-ui/tabs'
@@ -50,7 +51,7 @@ function App() {
   const [quadkey, setQuadkey] = useState(null)
   const [bbox, setBbox] = useState(null)
   const drawRef = useRef()
-  const [activeTab, setActiveTab] = useState('web')
+  const [activeTab, setActiveTab] = useState(null)
 
   const startDrawingBbox = () => {
     if (
@@ -225,6 +226,17 @@ function App() {
     })
   }
 
+  useEffect(()=> {
+    const storedPlatform = localStorage.getItem('LocationHelper.platform')
+    const active = storedPlatform || 'web'
+    setActiveTab(active)
+  },[])
+
+  function tabsClick(id) {
+    setActiveTab(id)
+    localStorage.setItem('LocationHelper.platform', id)
+  }
+
   const displayZoom = format(zoom, 2)
   const displayBearing = format(bearing, 2)
   const displayPitch = format(pitch, 2)
@@ -294,7 +306,7 @@ function App() {
         </div>
 
         <Tabs
-          onChange={(id) => setActiveTab(id)}
+          onChange={(id) => tabsClick(id)}
           active={activeTab}
           activeColor={'blue'}
           hoverColor={'gray-dark'}
@@ -329,6 +341,15 @@ function App() {
                 bbox={bbox}
                 zxy={zxy}
                 />  },
+            { id: 'flutter', label: 'Flutter', content: <Flutter 
+              center={center}
+              displayZoom={displayZoom} 
+              displayBearing={displayBearing}
+              displayPitch={displayPitch}
+              bounds={bounds}                
+              bbox={bbox}
+              zxy={zxy}
+              />  },
           ]}
         />
 

--- a/projects/location-helper/src/BasePlatform.jsx
+++ b/projects/location-helper/src/BasePlatform.jsx
@@ -1,0 +1,61 @@
+// BaseComponent.js
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import TableRow from './TableRow';
+
+const BasePlatform = ({
+    center,
+    displayZoom,
+    displayBearing,
+    displayPitch,
+    bounds,
+    bbox,
+    zxy,
+    formatCenter,
+    formatCenterObject,
+    formatBounds,
+    formatBbox
+}) => {
+    const [displayBbox, setDisplayBbox] = useState('Use the polygon button to draw a bounding box');
+
+    useEffect(() => {
+        if (bbox) {
+            const bounding = formatBbox(bbox);
+            setDisplayBbox(bounding);
+        }
+    }, [bbox, formatBbox]);
+    
+    const isWeb = formatCenterObject ? true : false;
+
+    return (
+        <div className='overflow-x-auto relative'>
+            <TableRow label={isWeb ? 'center(array)' : 'center'} value={formatCenter(center)} /> 
+            {
+                isWeb &&
+                <TableRow label='center (object)' value={formatCenterObject(center)} />
+            }
+            <TableRow label='zoom' value={displayZoom} />
+            <TableRow label='bearing' value={displayBearing} />
+            <TableRow label='pitch' value={displayPitch} />
+            <TableRow label='viewport bounds' value={formatBounds(bounds)} noBorder />
+            <TableRow label='user-drawn bounding box' value={displayBbox} noBorder />
+            <TableRow label='z/x/y tile' value={zxy} noBorder />
+        </div>
+    );
+};
+
+BasePlatform.propTypes = {
+    center: PropTypes.object,
+    displayZoom: PropTypes.string,
+    displayBearing: PropTypes.string,
+    displayPitch: PropTypes.string,
+    bounds: PropTypes.object,
+    bbox: PropTypes.array,
+    zxy: PropTypes.any,
+    formatCenter: PropTypes.func.isRequired,
+    formatCenterObject: PropTypes.func,
+    formatBounds: PropTypes.func.isRequired,
+    formatBbox: PropTypes.func.isRequired
+};
+
+export default BasePlatform;

--- a/projects/location-helper/src/Futter.jsx
+++ b/projects/location-helper/src/Futter.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import TableRow from "./TableRow"
 import { format } from './utils'
 
-const Ios = ({
+const Flutter = ({
     center,
     displayZoom, 
     displayBearing, 
@@ -23,38 +23,41 @@ const Ios = ({
     
     function processCenter(centerArray) {
         return (
-`CLLocationCoordinate2D(
-  latitude: ${format(centerArray.lat, 5)}, 
-  longitude: ${format(centerArray.lng, 5)}
-)`)
+`Point(
+  coordinates: Position(
+    ${format(centerArray.lat, 5)}, 
+    ${format(centerArray.lng, 5)}
+))`)
     }
 
     function formatBoundsArray(bounds) {
         return (
 `CoordinateBounds(
-  southwest: CLLocationCoordinate2D(
-    latitude:  ${format(bounds._sw.lat, 5)}, 
-    longitude: ${format(bounds._sw.lng, 5)}
-  ),
-  northeast: CLLocationCoordinate2D(
-    latitude: ${format(bounds._ne.lat, 5)}, 
-    longitude: ${format(bounds._ne.lng, 5)}
-  )
+  southwest: Point(
+    coordinates: Position(
+      ${format(bounds._sw.lat, 5)}, ${format(bounds._sw.lng, 5)}
+  )),
+  northeast: Point(
+    coordinates: Position(
+      ${format(bounds._ne.lat, 5)},  ${format(bounds._ne.lng, 5)}
+  )),
+  infiniteBounds: false
 )`)
     }
 
     function formatBoundingBox(bbox) {
         return (
 `CoordinateBounds(
-  southwest: CLLocationCoordinate2D(
-    latitude:  ${format(bbox[1], 5)}, 
-    longitude: ${format(bbox[0], 5)}
-  ),
-  northeast: CLLocationCoordinate2D(
-    latitude: ${format(bbox[3], 5)}, 
-    longitude: ${format(bbox[2], 5)}
-  )
-)`)
+    southwest: Point(
+      coordinates: Position(
+        ${format(bbox[1], 5)}, ${format(bbox[0], 5)}
+    )),
+    northeast: Point(
+      coordinates: Position(
+        ${format(bbox[3], 5)},  ${format(bbox[2], 5)}
+    )),
+    infiniteBounds: false
+  )`)
     }
      
     return (
@@ -79,9 +82,9 @@ const Ios = ({
     )
 }
 
-export default Ios
+export default Flutter
 
-Ios.propTypes = {
+Flutter.propTypes = {
     center: PropTypes.object,
     displayZoom: PropTypes.string,
     displayBearing: PropTypes.string,

--- a/projects/location-helper/src/Futter.jsx
+++ b/projects/location-helper/src/Futter.jsx
@@ -1,26 +1,11 @@
-import React, { useState, useEffect } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
-import TableRow from "./TableRow"
+
 import { format } from './utils'
+import BasePlatform from './BasePlatform'
 
-const Flutter = ({
-    center,
-    displayZoom, 
-    displayBearing, 
-    displayPitch, 
-    bounds, 
-    bbox,
-    zxy }) => {
+const Flutter = (props) => {
      
-    const [displayBbox, setDisplayBbox ] = useState('use the polygon button to draw a bounding box')
-
-    useEffect(()=> {
-        if(bbox) {
-            const bounding = formatBoundingBox(bbox);
-            setDisplayBbox(bounding)
-        }
-    }, [bbox])
-    
     function processCenter(centerArray) {
         return (
 `Point(
@@ -60,36 +45,7 @@ const Flutter = ({
   )`)
     }
      
-    return (
-
-        <div className='overflow-x-auto relative'>
-          <TableRow label='center' value={processCenter(center)} />
-          <TableRow label='zoom' value={displayZoom} />
-          <TableRow label='bearing' value={displayBearing} />
-          <TableRow label='pitch' value={displayPitch} />
-          <TableRow
-            label={`viewport \n bounds`}
-            value={formatBoundsArray(bounds)}
-            noBorder
-          />
-          <TableRow
-            label='user-drawn bounding box'
-            value={displayBbox}
-            noBorder
-          />
-          <TableRow label='z/x/y tile' value={zxy} noBorder />
-        </div>
-    )
+    return <BasePlatform {...props} formatCenter={processCenter} formatBounds={formatBoundsArray} formatBbox={formatBoundingBox} />
 }
 
 export default Flutter
-
-Flutter.propTypes = {
-    center: PropTypes.object,
-    displayZoom: PropTypes.string,
-    displayBearing: PropTypes.string,
-    displayPitch: PropTypes.string,
-    bounds: PropTypes.object, 
-    displayBbox: PropTypes.any,
-    zxy: PropTypes.any
-}

--- a/projects/location-helper/src/Ios.jsx
+++ b/projects/location-helper/src/Ios.jsx
@@ -1,0 +1,77 @@
+import React, { useState, useEffect } from 'react'
+import PropTypes from 'prop-types'
+import TableRow from "./TableRow"
+import { format } from './utils'
+
+const Ios = ({
+    center,
+    displayZoom, 
+    displayBearing, 
+    displayPitch, 
+    bounds, 
+    bbox,
+    zxy }) => {
+     
+    console.log("center", center)
+    const [displayBbox, setDisplayBbox ] = useState('use the polygon button to draw a bounding box')
+
+    useEffect(()=> {
+        if(bbox) {
+            const bounding = formatBoundingBox(bbox);
+            setDisplayBbox(bounding)
+        }
+    }, [bbox])
+    
+    function processCenter(centerArray) {
+        const iosCenter = `CLLocationCoordinate2D(latitude: ${format(centerArray.lat, 5)}, longitude: ${format(centerArray.lng, 5)})`
+        return iosCenter
+    }
+
+    function formatBoundsArray(bounds) {
+        return `CoordinateBounds(
+                    southwest: CLLocationCoordinate2D(latitude:  ${format(bounds._sw.lat, 5)}, longitude: ${format(bounds._sw.lng, 5)}),
+                    northeast: CLLocationCoordinate2D(latitude: ${format(bounds._ne.lat, 5)}, longitude: ${format(bounds._ne.lng, 5)})
+                )`
+    }
+
+    function formatBoundingBox(bbox) {
+        return `CoordinateBounds(
+                    southwest: CLLocationCoordinate2D(latitude:  ${format(bbox[1], 5)}, longitude: ${format(bbox[0], 5)}),
+                    northeast: CLLocationCoordinate2D(latitude: ${format(bbox[3], 5)}, longitude: ${format(bbox[2], 5)})
+                )`
+    }
+     
+    return (
+
+        <div className='overflow-x-auto relative'>
+          <TableRow label='center' value={processCenter(center)} />
+          <TableRow label='zoom' value={displayZoom} />
+          <TableRow label='bearing' value={displayBearing} />
+          <TableRow label='pitch' value={displayPitch} />
+          <TableRow
+            label='viewport bounds'
+            value={formatBoundsArray(bounds)}
+            noBorder
+          />
+          <TableRow
+            label='user-drawn bounding box'
+            value={displayBbox}
+            noBorder
+          />
+          <TableRow label='z/x/y tile' value={zxy} noBorder />
+        </div>
+    )
+}
+
+export default Ios
+
+Ios.propTypes = {
+    displayCenterArray: PropTypes.array,
+    displayCenterObject: PropTypes.object,
+    displayZoom: PropTypes.number,
+    displayBearing: PropTypes.number,
+    displayPitch: PropTypes.number,
+    displayBoundsArray: PropTypes.array, 
+    displayBbox: PropTypes.array,
+    zxy: PropTypes.any
+}

--- a/projects/location-helper/src/Ios.jsx
+++ b/projects/location-helper/src/Ios.jsx
@@ -12,7 +12,6 @@ const Ios = ({
     bbox,
     zxy }) => {
      
-    console.log("center", center)
     const [displayBbox, setDisplayBbox ] = useState('use the polygon button to draw a bounding box')
 
     useEffect(()=> {
@@ -23,22 +22,27 @@ const Ios = ({
     }, [bbox])
     
     function processCenter(centerArray) {
-        const iosCenter = `CLLocationCoordinate2D(latitude: ${format(centerArray.lat, 5)}, longitude: ${format(centerArray.lng, 5)})`
-        return iosCenter
+        return (
+`CLLocationCoordinate2D(
+    latitude: ${format(centerArray.lat, 5)}, 
+    longitude: ${format(centerArray.lng, 5)}
+)`)
     }
 
     function formatBoundsArray(bounds) {
-        return `CoordinateBounds(
-                    southwest: CLLocationCoordinate2D(latitude:  ${format(bounds._sw.lat, 5)}, longitude: ${format(bounds._sw.lng, 5)}),
-                    northeast: CLLocationCoordinate2D(latitude: ${format(bounds._ne.lat, 5)}, longitude: ${format(bounds._ne.lng, 5)})
-                )`
+        return (
+`CoordinateBounds(
+    southwest: CLLocationCoordinate2D(latitude:  ${format(bounds._sw.lat, 5)}, longitude: ${format(bounds._sw.lng, 5)}),
+    northeast: CLLocationCoordinate2D(latitude: ${format(bounds._ne.lat, 5)}, longitude: ${format(bounds._ne.lng, 5)})
+)`)
     }
 
     function formatBoundingBox(bbox) {
-        return `CoordinateBounds(
-                    southwest: CLLocationCoordinate2D(latitude:  ${format(bbox[1], 5)}, longitude: ${format(bbox[0], 5)}),
-                    northeast: CLLocationCoordinate2D(latitude: ${format(bbox[3], 5)}, longitude: ${format(bbox[2], 5)})
-                )`
+        return (
+`CoordinateBounds(
+    southwest: CLLocationCoordinate2D(latitude:  ${format(bbox[1], 5)}, longitude: ${format(bbox[0], 5)}),
+    northeast: CLLocationCoordinate2D(latitude: ${format(bbox[3], 5)}, longitude: ${format(bbox[2], 5)})
+)`)
     }
      
     return (
@@ -66,12 +70,11 @@ const Ios = ({
 export default Ios
 
 Ios.propTypes = {
-    displayCenterArray: PropTypes.array,
-    displayCenterObject: PropTypes.object,
-    displayZoom: PropTypes.number,
-    displayBearing: PropTypes.number,
-    displayPitch: PropTypes.number,
-    displayBoundsArray: PropTypes.array, 
-    displayBbox: PropTypes.array,
+    center: PropTypes.object,
+    displayZoom: PropTypes.string,
+    displayBearing: PropTypes.string,
+    displayPitch: PropTypes.string,
+    bounds: PropTypes.object, 
+    displayBbox: PropTypes.any,
     zxy: PropTypes.any
 }

--- a/projects/location-helper/src/Ios.jsx
+++ b/projects/location-helper/src/Ios.jsx
@@ -32,16 +32,28 @@ const Ios = ({
     function formatBoundsArray(bounds) {
         return (
 `CoordinateBounds(
-    southwest: CLLocationCoordinate2D(latitude:  ${format(bounds._sw.lat, 5)}, longitude: ${format(bounds._sw.lng, 5)}),
-    northeast: CLLocationCoordinate2D(latitude: ${format(bounds._ne.lat, 5)}, longitude: ${format(bounds._ne.lng, 5)})
+    southwest: CLLocationCoordinate2D(
+        latitude:  ${format(bounds._sw.lat, 5)}, 
+        longitude: ${format(bounds._sw.lng, 5)}
+    ),
+    northeast: CLLocationCoordinate2D(
+        latitude: ${format(bounds._ne.lat, 5)}, 
+        longitude: ${format(bounds._ne.lng, 5)}
+    )
 )`)
     }
 
     function formatBoundingBox(bbox) {
         return (
 `CoordinateBounds(
-    southwest: CLLocationCoordinate2D(latitude:  ${format(bbox[1], 5)}, longitude: ${format(bbox[0], 5)}),
-    northeast: CLLocationCoordinate2D(latitude: ${format(bbox[3], 5)}, longitude: ${format(bbox[2], 5)})
+    southwest: CLLocationCoordinate2D(
+        latitude:  ${format(bbox[1], 5)}, 
+        longitude: ${format(bbox[0], 5)}
+    ),
+    northeast: CLLocationCoordinate2D(
+        latitude: ${format(bbox[3], 5)}, 
+        longitude: ${format(bbox[2], 5)}
+    )
 )`)
     }
      
@@ -53,7 +65,7 @@ const Ios = ({
           <TableRow label='bearing' value={displayBearing} />
           <TableRow label='pitch' value={displayPitch} />
           <TableRow
-            label='viewport bounds'
+            label={`viewport \n bounds`}
             value={formatBoundsArray(bounds)}
             noBorder
           />

--- a/projects/location-helper/src/Ios.jsx
+++ b/projects/location-helper/src/Ios.jsx
@@ -1,25 +1,8 @@
-import React, { useState, useEffect } from 'react'
-import PropTypes from 'prop-types'
-import TableRow from "./TableRow"
+import React from 'react'
+import BasePlatform from './BasePlatform'
 import { format } from './utils'
 
-const Ios = ({
-    center,
-    displayZoom, 
-    displayBearing, 
-    displayPitch, 
-    bounds, 
-    bbox,
-    zxy }) => {
-     
-    const [displayBbox, setDisplayBbox ] = useState('use the polygon button to draw a bounding box')
-
-    useEffect(()=> {
-        if(bbox) {
-            const bounding = formatBoundingBox(bbox);
-            setDisplayBbox(bounding)
-        }
-    }, [bbox])
+const Ios = (props) => {
     
     function processCenter(centerArray) {
         return (
@@ -57,36 +40,7 @@ const Ios = ({
 )`)
     }
      
-    return (
-
-        <div className='overflow-x-auto relative'>
-          <TableRow label='center' value={processCenter(center)} />
-          <TableRow label='zoom' value={displayZoom} />
-          <TableRow label='bearing' value={displayBearing} />
-          <TableRow label='pitch' value={displayPitch} />
-          <TableRow
-            label={`viewport \n bounds`}
-            value={formatBoundsArray(bounds)}
-            noBorder
-          />
-          <TableRow
-            label='user-drawn bounding box'
-            value={displayBbox}
-            noBorder
-          />
-          <TableRow label='z/x/y tile' value={zxy} noBorder />
-        </div>
-    )
+    return <BasePlatform { ...props} formatCenter={processCenter} formatBounds={formatBoundsArray} formatBbox={formatBoundingBox}/>
 }
 
 export default Ios
-
-Ios.propTypes = {
-    center: PropTypes.object,
-    displayZoom: PropTypes.string,
-    displayBearing: PropTypes.string,
-    displayPitch: PropTypes.string,
-    bounds: PropTypes.object, 
-    displayBbox: PropTypes.any,
-    zxy: PropTypes.any
-}

--- a/projects/location-helper/src/TableRow.jsx
+++ b/projects/location-helper/src/TableRow.jsx
@@ -10,13 +10,13 @@ const TableRow = ({ label, value, noBorder }) => (
     >
       <div
         scope='row'
-        className='w120 align-r py3 txt-s txt-bold flex-child-no-shrink'
+        className='w-1/4 align-r py3 txt-s txt-bold flex-child-no-shrink'
       >
         {label}
       </div>
       <div 
         className='txt-mono txt-ms pl12 flex-child-grow copiable-container overflow-auto'
-        //style={{whiteSpace: "pre"}}
+        style={{whiteSpace: "pre"}}
         >
         <Copiable value={value} />
       </div>

--- a/projects/location-helper/src/TableRow.jsx
+++ b/projects/location-helper/src/TableRow.jsx
@@ -14,7 +14,10 @@ const TableRow = ({ label, value, noBorder }) => (
       >
         {label}
       </div>
-      <div className='txt-mono txt-ms pl12 flex-child-grow copiable-container overflow-auto'>
+      <div 
+        className='txt-mono txt-ms pl12 flex-child-grow copiable-container overflow-auto'
+        //style={{whiteSpace: "pre"}}
+        >
         <Copiable value={value} />
       </div>
     </div>

--- a/projects/location-helper/src/TableRow.jsx
+++ b/projects/location-helper/src/TableRow.jsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Copiable from '@mapbox/mr-ui/copiable'
+
+const TableRow = ({ label, value, noBorder }) => (
+    <div
+      className={`flex flex--center-cross py3 ${
+        !noBorder && 'border-b border--gray-light'
+      }`}
+    >
+      <div
+        scope='row'
+        className='w120 align-r py3 txt-s txt-bold flex-child-no-shrink'
+      >
+        {label}
+      </div>
+      <div className='txt-mono txt-ms pl12 flex-child-grow copiable-container overflow-auto'>
+        <Copiable value={value} />
+      </div>
+    </div>
+  )
+
+  export default TableRow
+  
+  TableRow.propTypes = {
+    label: PropTypes.any,
+    noBorder: PropTypes.any,
+    value: PropTypes.any
+  }

--- a/projects/location-helper/src/Web.jsx
+++ b/projects/location-helper/src/Web.jsx
@@ -30,18 +30,24 @@ const Web = ({
     } 
 
     function formatBoundsArray(bounds) {
-        return `[[${format(bounds._sw.lng, 5)}, ${format(bounds._sw.lat, 5)}], 
-            [${format(bounds._ne.lng, 5)}, ${format(bounds._ne.lat, 5)}]]`
+        return (
+`[
+    [${format(bounds._sw.lng, 5)}, ${format(bounds._sw.lat, 5)}], 
+    [${format(bounds._ne.lng, 5)}, ${format(bounds._ne.lat, 5)}]
+]`)
     }
 
     function formatBoundingBox(bbox) {
-        return `[[${format(bbox[0], 5)}, ${format(bbox[1], 5)}],
-            [${format(bbox[2],5)}, ${format(bbox[3], 5)}]]`
+        return (
+`[
+    [${format(bbox[0], 5)}, ${format(bbox[1], 5)}],
+    [${format(bbox[2],5)}, ${format(bbox[3], 5)}]
+]`)
       }
 
     return (
 
-        <div className='overflow-x-auto relative'>
+        <div className='overflow-auto relative'>
           <TableRow label='center (array)' value={formatCenterArray(center)} />
           <TableRow label='center (object)' value={formatCenterObject(center)} />
           <TableRow label='zoom' value={displayZoom} />
@@ -65,12 +71,11 @@ const Web = ({
 export default Web
 
 Web.propTypes = {
-    displayCenterArray: PropTypes.array,
-    displayCenterObject: PropTypes.object,
-    displayZoom: PropTypes.number,
-    displayBearing: PropTypes.number,
-    displayPitch: PropTypes.number,
-    displayBoundsArray: PropTypes.array, 
-    displayBbox: PropTypes.array,
+    center: PropTypes.object,
+    displayZoom: PropTypes.string,
+    displayBearing: PropTypes.string,
+    displayPitch: PropTypes.string,
+    bounds: PropTypes.object, 
+    displayBbox: PropTypes.any,
     zxy: PropTypes.any
 }

--- a/projects/location-helper/src/Web.jsx
+++ b/projects/location-helper/src/Web.jsx
@@ -1,0 +1,76 @@
+import React, { useState, useEffect } from 'react'
+import PropTypes from 'prop-types'
+import TableRow from "./TableRow"
+import { format } from './utils'
+
+const Web = ({
+    center, 
+    displayZoom, 
+    displayBearing, 
+    displayPitch, 
+    bounds,
+    bbox,
+    zxy }) => {
+
+    const [displayBbox, setDisplayBbox ] = useState('use the polygon button to draw a bounding box')
+
+    useEffect(()=> {
+        if(bbox) {
+            const bounding = formatBoundingBox(bbox);
+            setDisplayBbox(bounding)
+        }
+    }, [bbox])
+
+    function formatCenterArray(center) {
+        return `[${format(center.lng, 5)}, ${format(center.lat, 5)}]`
+    } 
+
+    function formatCenterObject(center) {
+        return `{lng: ${format(center.lng, 5)}, lat: ${format(center.lat, 5)}}`
+    } 
+
+    function formatBoundsArray(bounds) {
+        return `[[${format(bounds._sw.lng, 5)}, ${format(bounds._sw.lat, 5)}], 
+            [${format(bounds._ne.lng, 5)}, ${format(bounds._ne.lat, 5)}]]`
+    }
+
+    function formatBoundingBox(bbox) {
+        return `[[${format(bbox[0], 5)}, ${format(bbox[1], 5)}],
+            [${format(bbox[2],5)}, ${format(bbox[3], 5)}]]`
+      }
+
+    return (
+
+        <div className='overflow-x-auto relative'>
+          <TableRow label='center (array)' value={formatCenterArray(center)} />
+          <TableRow label='center (object)' value={formatCenterObject(center)} />
+          <TableRow label='zoom' value={displayZoom} />
+          <TableRow label='bearing' value={displayBearing} />
+          <TableRow label='pitch' value={displayPitch} />
+          <TableRow
+            label='viewport bounds'
+            value={formatBoundsArray(bounds)}
+            noBorder
+          />
+          <TableRow
+            label='user-drawn bounding box'
+            value={displayBbox}
+            noBorder
+          />
+          <TableRow label='z/x/y tile' value={zxy} noBorder />
+        </div>
+    )
+}
+
+export default Web
+
+Web.propTypes = {
+    displayCenterArray: PropTypes.array,
+    displayCenterObject: PropTypes.object,
+    displayZoom: PropTypes.number,
+    displayBearing: PropTypes.number,
+    displayPitch: PropTypes.number,
+    displayBoundsArray: PropTypes.array, 
+    displayBbox: PropTypes.array,
+    zxy: PropTypes.any
+}

--- a/projects/location-helper/src/Web.jsx
+++ b/projects/location-helper/src/Web.jsx
@@ -1,25 +1,8 @@
-import React, { useState, useEffect } from 'react'
-import PropTypes from 'prop-types'
-import TableRow from "./TableRow"
+import React from 'react'
+import BasePlatform from './BasePlatform'
 import { format } from './utils'
 
-const Web = ({
-    center, 
-    displayZoom, 
-    displayBearing, 
-    displayPitch, 
-    bounds,
-    bbox,
-    zxy }) => {
-
-    const [displayBbox, setDisplayBbox ] = useState('use the polygon button to draw a bounding box')
-
-    useEffect(()=> {
-        if(bbox) {
-            const bounding = formatBoundingBox(bbox);
-            setDisplayBbox(bounding)
-        }
-    }, [bbox])
+const Web = (props) => {
 
     function formatCenterArray(center) {
         return `[${format(center.lng, 5)}, ${format(center.lat, 5)}]`
@@ -45,37 +28,7 @@ const Web = ({
 ]`)
       }
 
-    return (
-
-        <div className='overflow-auto relative'>
-          <TableRow label='center (array)' value={formatCenterArray(center)} />
-          <TableRow label='center (object)' value={formatCenterObject(center)} />
-          <TableRow label='zoom' value={displayZoom} />
-          <TableRow label='bearing' value={displayBearing} />
-          <TableRow label='pitch' value={displayPitch} />
-          <TableRow
-            label='viewport bounds'
-            value={formatBoundsArray(bounds)}
-            noBorder
-          />
-          <TableRow
-            label='user-drawn bounding box'
-            value={displayBbox}
-            noBorder
-          />
-          <TableRow label='z/x/y tile' value={zxy} noBorder />
-        </div>
-    )
+      return <BasePlatform {...props} formatCenter={formatCenterArray} formatCenterObject={formatCenterObject} formatBounds={formatBoundsArray} formatBbox={formatBoundingBox} />
 }
 
 export default Web
-
-Web.propTypes = {
-    center: PropTypes.object,
-    displayZoom: PropTypes.string,
-    displayBearing: PropTypes.string,
-    displayPitch: PropTypes.string,
-    bounds: PropTypes.object, 
-    displayBbox: PropTypes.any,
-    zxy: PropTypes.any
-}

--- a/projects/location-helper/src/utils.js
+++ b/projects/location-helper/src/utils.js
@@ -1,0 +1,3 @@
+export const format = (d, n) => {
+    return d.toFixed(n).replace(/[.,]00$/, '')
+}


### PR DESCRIPTION
## Updated PR 👇 

This PR adds a Tabs UI to the response fields of the sidebar to allow a user to toggle between Web/iOS/Android to provide a quicker and more useful snippet for the user to copy/paste into their code.  The format of these objects differ in the mobile SDK's and don't match what is returned for Web based usage in GL JS. 

### Android Format 
In Android a point or center object is returned like this..

```
Point.fromLngLat(-3.363937, -10.733102)
```
And a bounding box like this..

```
  CoordinateBounds(
    Point.fromLngLat(-122.66336, 37.492987),
    Point.fromLngLat(-122.250481, 37.87165),
    false
  )    
```

### iOS Format
```
CLLocationCoordinate2D(latitude: 40.7135, longitude: -74.0066)
```

```
CoordinateBounds(
  southwest: CLLocationCoordinate2D(latitude: 63.33, longitude: -25.52),
  northeast: CLLocationCoordinate2D(latitude: 66.61, longitude: -13.47))
```

### Flutter 

```
Point(coordinates: Position(-74.00913, 40.75183))
```

```
CoordinateBounds(
  southwest: Point(coordinates: Position(Lat, Long)),
  northeast: Point(coordinates: Position(Lat, Long)),
  infiniteBounds: false
)
```

## Implementation 
To implement this additional feature set to the Location Helper I've imported `mr-ui`'s `Tabs` component, and refactored the single `App.jsx` into multiple components, which process the core data into their respective formats.  

Screenshot here
<img width="1004" alt="Screenshot 2024-10-29 at 10 35 30 AM" src="https://github.com/user-attachments/assets/5c332e0a-e0ee-4ba7-b7a0-f845b82efcbe">


## Formatting of Snippets
The focus of this tool is to create useful snippets of code for a developer to past into their code.  The problem with this UI is that it uses `mr-ui`'s `Copiable` component which does [not support horizontal scrolling](https://github.com/mapbox/mr-ui/blob/d9d81fdab2106cfd921cfef28ca5c94e9b75105a/src/components/copiable/copiable.tsx#L158) To move beyond this I've played with sizing and layout, and edited how the snippets are broken into new lines, to keep them within the width of the sidebar.

If this mutli-line format makes the copiable code not as useful to devs, then I would think it may be worth building a bespoke solution to replace the `Copiable` component. OR importing our `CodeBlock` component from `docsuaurus-packages`.


## Testing
This is available for testing on staging https://labs.tilestream.net/location-helper

- Test That the tabs inteface works as expected.
- Test that the Tab you have chosen is remember after you reload the page
- Ensure the formatting of code snippets are consistent,
- Note any layout issues

