### PR TITLE
Added Segment tracking to storytelling, realeastate & store-locator &…

### DIFF
--- a/projects/demo-realestate/index.html
+++ b/projects/demo-realestate/index.html
@@ -5,6 +5,20 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Real Estate App | Mapbox Developer Demo</title>
+
+    <!-- Add segment tracking for tool usage -->
+    <script src="https://docs.mapbox.com/analytics.min.js"></script>
+    <script>
+      window.mbxMetadata = {
+        content_type: 'developer-tool'
+      };
+
+      // eslint-disable-next-line no-undef
+      initializeMapboxAnalytics({
+        marketoMunchkin: false
+      });
+    </script>
+    
   </head>
   <body>
     <div id="root"></div>

--- a/projects/demo-store-locator/index.html
+++ b/projects/demo-store-locator/index.html
@@ -5,6 +5,20 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Store Locator | Mapbox Developer Demo</title>
+
+       <!-- Add segment tracking for tool usage -->
+       <script src="https://docs.mapbox.com/analytics.min.js"></script>
+       <script>
+         window.mbxMetadata = {
+           content_type: 'developer-tool'
+         };
+   
+         // eslint-disable-next-line no-undef
+         initializeMapboxAnalytics({
+           marketoMunchkin: false
+         });
+       </script>
+       
   </head>
   <body>
     <div id="root"></div>

--- a/projects/location-helper/index.html
+++ b/projects/location-helper/index.html
@@ -13,6 +13,20 @@
       content="quickly get center, zoom, bearing, and pitch on an interactive map"
     />
     <title>Location Helper | Mapbox Spatial Developer Tools</title>
+
+    <!-- Add segment tracking for tool usage -->
+    <script src="https://docs.mapbox.com/analytics.min.js"></script>
+    <script>
+      window.mbxMetadata = {
+        content_type: 'developer-tool'
+      };
+
+      // eslint-disable-next-line no-undef
+      initializeMapboxAnalytics({
+        marketoMunchkin: false
+      });
+    </script>
+
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/projects/storytelling/index.html
+++ b/projects/storytelling/index.html
@@ -13,6 +13,20 @@
       content="Demonstration of dynamic camera and map controls based on the user's scrolling position"
     />
     <title>Mapbox Storytelling Demo | Mapbox Spatial Developer Tools</title>
+    
+      <!-- Add segment tracking for tool usage -->
+      <script src="https://docs.mapbox.com/analytics.min.js"></script>
+      <script>
+        window.mbxMetadata = {
+          content_type: 'developer-tool'
+        };
+  
+        // eslint-disable-next-line no-undef
+        initializeMapboxAnalytics({
+          marketoMunchkin: false
+        });
+      </script>
+
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
This PR adds our `@mapbox/web-analytics` script to the following projects..

- Real Estate Demo
- Store Locator Demo
- Location Helper
- StoryTelling

This will allow us to track usage/page visits to these tools & demos.  

## Notes
Rather than add the `@mapbox/web-analytics` package to these projects, I've repeated a pattern of inlining the script hosted on docs.mapbox.com and initializing the script at the top level index.html so that the core application code (`App.jsx`) stays a clean as possible for the public/developers.

## Testing 
Pull down this branch, launch each project and ensure that the segment `p` event is firing and header requests include properties `content-type: developer-tool`.