### PR TITLE
Fix Developer CheatSheet Links & Refactor PageShell component

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,7 +12,8 @@
     ],
     "ignorePatterns": [
         "dist",
-        ".eslintrc.cjs"
+        ".eslintrc.cjs",
+         "**/*.html"
     ],
     "parserOptions": {
         "ecmaVersion": "latest",

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,2 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
 
 npx lint-staged

--- a/projects/demo-components/src/access-token.jsx
+++ b/projects/demo-components/src/access-token.jsx
@@ -1,4 +1,4 @@
 const accessToken =
-  'pk.eyJ1IjoibGFicy1zYW5kYm94IiwiYSI6ImNrMTZuanRmZDA2eGQzYmxqZTlnd21qY3EifQ.Q7DM5HqE5QJzDEnCx8BGFw'
+  'pk.eyJ1IjoiZXhhbXBsZXMiLCJhIjoiY203dWs2ajdhMDFnbDJscHRtY2liNnB1byJ9.EsCqiekql3X53WHrRiZ0rg'
 
 export default accessToken

--- a/projects/demo-components/src/access-token.jsx
+++ b/projects/demo-components/src/access-token.jsx
@@ -1,4 +1,4 @@
 const accessToken =
-  'pk.eyJ1IjoiZXhhbXBsZXMiLCJhIjoiY203dWs2ajdhMDFnbDJscHRtY2liNnB1byJ9.EsCqiekql3X53WHrRiZ0rg'
+  'pk.eyJ1IjoibGFicy1zYW5kYm94IiwiYSI6ImNrMTZuanRmZDA2eGQzYmxqZTlnd21qY3EifQ.Q7DM5HqE5QJzDEnCx8BGFw'
 
 export default accessToken

--- a/projects/demo-components/src/mapbox-tooltip.jsx
+++ b/projects/demo-components/src/mapbox-tooltip.jsx
@@ -1,12 +1,11 @@
 // Mapbox Tooltip - for adding hints about Mapbox features
-
 import PropTypes from 'prop-types'
 import { Tooltip } from 'react-tooltip'
 import Markdown from 'react-markdown'
 import classNames from 'classnames'
 import LogoSVG from './logo-svg'
 
-const Content = ({ markdownString, linkColor }) => {
+const Content = ({ markdownString }) => {
   return (
     <Markdown
       components={{
@@ -89,7 +88,8 @@ const MapboxTooltip = ({ className, title, content, linkColor }) => {
 MapboxTooltip.propTypes = {
   content: PropTypes.string,
   className: PropTypes.any,
-  title: PropTypes.string
+  title: PropTypes.string,
+  linkColor: PropTypes.string
 }
 
 export default MapboxTooltip

--- a/projects/demo-components/src/mapbox-tooltips.jsx
+++ b/projects/demo-components/src/mapbox-tooltips.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { useState } from 'react'
+import { useState } from 'react'
 import MapboxTooltip from './mapbox-tooltip'
 import LogoSVG from './logo-svg'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -50,7 +50,7 @@ const MapboxTooltips = ({ products }) => {
 
 export default MapboxTooltips
 
-MapboxTooltips.PropTypes = {
+MapboxTooltips.propTypes = {
   products: PropTypes.array,
   bgColor: PropTypes.string // desired color needs to match map colorVariants. Add additional colors in colorVariants
 }

--- a/projects/demo-components/src/page-shell.jsx
+++ b/projects/demo-components/src/page-shell.jsx
@@ -1,26 +1,17 @@
 import { useEffect } from 'react'
-import '@mapbox/web-analytics'
 
 const PageShell = ({ children }) => {
   useEffect(() => {
+    // @mapbox/web-analytics is inline in the HTML index.html for each project
     // set mapbox metadata before initializing analytics
     window.mbxMetadata = {
-      product: 'Mapbox GL JS', // comma delimited string
-      service: 'maps', // comma delimited string
-      platform: 'web', // comma delimited string
-      content_type: 'public-demos-and-tools' // single value string
+      content_type: 'developer-tool'
     }
 
-    // initialize analytics
-    if (window && window.initializeMapboxAnalytics) {
-      window.initializeMapboxAnalytics({
-        webAnalytics: {
-          segmentIntegrations: {
-            Drift: false
-          }
-        }
-      })
-    }
+    // eslint-disable-next-line no-undef
+    initializeMapboxAnalytics({
+      marketoMunchkin: false
+    })
   }, [])
   return children
 }

--- a/projects/demo-realestate/index.html
+++ b/projects/demo-realestate/index.html
@@ -5,6 +5,9 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Real Estate App | Mapbox Developer Demo</title>
+
+    <!-- Add segment tracking for tool usage -->
+    <script src="https://docs.mapbox.com/analytics.min.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/projects/demo-realestate/index.html
+++ b/projects/demo-realestate/index.html
@@ -5,20 +5,6 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Real Estate App | Mapbox Developer Demo</title>
-
-    <!-- Add segment tracking for tool usage -->
-    <script src="https://docs.mapbox.com/analytics.min.js"></script>
-    <script>
-      window.mbxMetadata = {
-        content_type: 'developer-tool'
-      };
-
-      // eslint-disable-next-line no-undef
-      initializeMapboxAnalytics({
-        marketoMunchkin: false
-      });
-    </script>
-    
   </head>
   <body>
     <div id="root"></div>

--- a/projects/demo-realestate/src/main.jsx
+++ b/projects/demo-realestate/src/main.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
+import { PageShell } from 'mapbox-demo-components'
 
 import App from './App'
 
@@ -8,8 +9,10 @@ const root = ReactDOM.createRoot(document.getElementById('root'))
 
 root.render(
   <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <PageShell>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </PageShell>
   </React.StrictMode>
 )

--- a/projects/demo-store-locator/index.html
+++ b/projects/demo-store-locator/index.html
@@ -6,19 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Store Locator | Mapbox Developer Demo</title>
 
-       <!-- Add segment tracking for tool usage -->
-       <script src="https://docs.mapbox.com/analytics.min.js"></script>
-       <script>
-         window.mbxMetadata = {
-           content_type: 'developer-tool'
-         };
-   
-         // eslint-disable-next-line no-undef
-         initializeMapboxAnalytics({
-           marketoMunchkin: false
-         });
-       </script>
-       
+    <!-- Add segment tracking for tool usage -->
+    <script src="https://docs.mapbox.com/analytics.min.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/projects/demo-store-locator/src/Map/index.jsx
+++ b/projects/demo-store-locator/src/Map/index.jsx
@@ -41,6 +41,8 @@ const Map = ({ onLoad }) => {
   mapboxgl.accessToken = accessToken
 
   useEffect(() => {
+    if (mapRef.current) return // map already initialized
+
     const map = (mapRef.current = new mapboxgl.Map({
       container: mapContainer.current,
       // this is a custom style, created with store location data loaded via Mapbox Tiling Service and styled in Mapbox Studio.

--- a/projects/demo-store-locator/src/main.jsx
+++ b/projects/demo-store-locator/src/main.jsx
@@ -6,6 +6,7 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import { AppContextProvider } from './Context/AppContext'
+import { PageShell } from 'mapbox-demo-components'
 
 import App from './App'
 
@@ -13,10 +14,12 @@ const root = ReactDOM.createRoot(document.getElementById('root'))
 
 root.render(
   <React.StrictMode>
-    <BrowserRouter>
-      <AppContextProvider>
-        <App />
-      </AppContextProvider>
-    </BrowserRouter>
+    <PageShell>
+      <BrowserRouter>
+        <AppContextProvider>
+          <App />
+        </AppContextProvider>
+      </BrowserRouter>
+    </PageShell>
   </React.StrictMode>
 )

--- a/projects/developer-cheatsheet/index.html
+++ b/projects/developer-cheatsheet/index.html
@@ -13,6 +13,9 @@
       content="Explore all Mapbox tools and services on an interactive grid layout."
     />
     <title>Developer Cheat Sheet | Mapbox Spatial Developer Tools</title>
+
+    <!-- Add segment tracking for tool usage -->
+    <script src="https://docs.mapbox.com/analytics.min.js"></script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/projects/developer-cheatsheet/public/css/output.css
+++ b/projects/developer-cheatsheet/public/css/output.css
@@ -1340,6 +1340,17 @@ h1 {
   border-radius: 8px;
 }
 
+.flip-card-front a {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.flip-card-front a div {
+  margin-top: 6px;
+}
+
 /* Style the back side */
 
 .flip-card-back {

--- a/projects/developer-cheatsheet/public/js/script.js
+++ b/projects/developer-cheatsheet/public/js/script.js
@@ -70,11 +70,13 @@ const getWidget = (item) => {
   <div class="flip-card grid-stack-item-content-inner tile category-${category}">
     <div class="flip-card-inner">
       <div class="flip-card-front category-${category}">
-        <svg width="40" height="40" class='icon'>
-            <path d="M20 40C31.0457 40 40 31.0457 40 20C40 8.9543 31.0457 0 20 0C8.9543 0 0 8.9543 0 20C0 31.0457 8.9543 40 20 40Z" fill="white"/>
-            <use xlink:href="img/shapes.svg#${icon}"></use>
-        </svg>
-        <div>${title}</div>
+        <a href = '${link}' target='_blank' noopener noreferrer>
+          <svg width="40" height="40" class='icon'>
+              <path d="M20 40C31.0457 40 40 31.0457 40 20C40 8.9543 31.0457 0 20 0C8.9543 0 0 8.9543 0 20C0 31.0457 8.9543 40 20 40Z" fill="white"/>
+              <use xlink:href="img/shapes.svg#${icon}"></use>
+          </svg>
+          <div>${title}</div>
+        </a>
       </div>
       <div class="flip-card-back category-${category}">
         <a href = '${link}' target='_blank' noopener noreferrer>

--- a/projects/location-helper/index.html
+++ b/projects/location-helper/index.html
@@ -16,17 +16,6 @@
 
     <!-- Add segment tracking for tool usage -->
     <script src="https://docs.mapbox.com/analytics.min.js"></script>
-    <script>
-      window.mbxMetadata = {
-        content_type: 'developer-tool'
-      };
-
-      // eslint-disable-next-line no-undef
-      initializeMapboxAnalytics({
-        marketoMunchkin: false
-      });
-    </script>
-
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
## Fix for Bug in Developer Cheatsheet
This PR fixes a bug in the [developer cheatsheet](https://labs.mapbox.com/developer-cheatsheet/) where when you click a category grouping, and then tiles for that category are flipped, the link for each item in the category became unavailable and you could not navigate to that Product/API/etc..  This was because the link was only available on a specific side of the card, and as the category button flips all cards, the link was then hidden.   This was reported in [Slack](https://mapbox.slack.com/archives/CDR31TFPG/p1744666712632829)

>[!Note]
> The PR was updated to add CSS styling which was broken in the initial fix of the problem above



This fix was deployed using the node script.

## Refactor of PageShell component
Secondly this PR refactors the `PageShell` which was essentially returning our `web-analytics` metadata to help track usage of these tools.  A recent [PR from the community](https://github.com/mapbox/public-tools-and-demos/pull/15) noted that `web-analytics` is a private package and was not available and was thus making the repo inoperable for the public.  

When adding tracking for more recent public tools and demos In #10 I foresaw this issue and used an inline version of web-analytics coming from S3 at the `index.html` in order to work around this.  I did not notice that web-analytics was still being used by `PageShell`.  This PR refactors the `PageShell` to no longer import `@mapbox/web-analytics` but just's initializes the tracking.  The script is moved to an inline script at the projects `index.html` file. 

