### PR TITLE
Refactor to remove access tokens & use local env variables to manage tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/node_modules/
 **/dist/
 .DS_Store
+.env

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ This purpose of this repo is to establish a framework for what makes a good publ
 
 Each project included in this repo is a react vite app.  React projects allow us to make use of reusable components, such as the UI components in `demo-components`, as well as `@mapbox/mr-ui` which includes buttons, icons, and other complex components used in Mapbox Studio, the Mapbox Docs, and other frontend things.
 
+## Access Tokens
+Running these projects locally require a valid Mapbox access token which you can get for free from you [Mapbox account](https://console.mapbox.com).  This repository uses a [Vite environment variable](https://vite.dev/guide/env-and-mode#env-variables) to share your access token across all the projects.  Rename the `projects/.env.sample` file to `.env` and replace `YOUR_MAPBOX_ACCESS_TOKEN` with the token from your account.  Now when you run any of the projects you'll be using your token.
+
 ## Local Development
 
 We use yarn workspaces to allow projects to consume shared components without having to publish them as a package to npm.  
@@ -17,7 +20,6 @@ After cloning the repository, install dependencies with `yarn`:
 ```
 > cd public-tools-and-demos && yarn
 ```
-
 This will install dependencies at the top level of the monorepo as well as in the individual project directories.
 
 Next, cd into the project directory you would like to work on, and start the dev server:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This purpose of this repo is to establish a framework for what makes a good publ
 
 Each project included in this repo is a react vite app.  React projects allow us to make use of reusable components, such as the UI components in `demo-components`, as well as `@mapbox/mr-ui` which includes buttons, icons, and other complex components used in Mapbox Studio, the Mapbox Docs, and other frontend things.
 
-## Access Tokens
+## Setup: Adding Your Public Access Token
 Running these projects locally require a valid Mapbox access token which you can get for free from you [Mapbox account](https://console.mapbox.com).  This repository uses a [Vite environment variable](https://vite.dev/guide/env-and-mode#env-variables) to share your access token across all the projects.  Rename the `projects/.env.sample` file to `.env` and replace `YOUR_MAPBOX_ACCESS_TOKEN` with the token from your account.  Now when you run any of the projects you'll be using your token.
 
 ## Local Development
@@ -67,12 +67,4 @@ Be sure to add the `import.meta.env.BASE_URL` globally injected variable when re
     }/${imageUrl}")`
   }}
 />
-```
-
-## Public AccessToken
-
-All projects should use the common accessToken from the `labs-sandbox` account, which can be imported from `demo-components`.  For projects that only need the access token to instantiate a map or add `mapbox-gl-geocoder`, this is handled for you in the `Map` component.
-
-```
-import AccessToken from 'demo-components'
 ```

--- a/projects/.env.sample
+++ b/projects/.env.sample
@@ -1,0 +1,2 @@
+# Add your access token and rename this file to .env
+VITE_YOUR_MAPBOX_ACCESS_TOKEN=replace_with_your_mapbox_access_token

--- a/projects/demo-components/src/access-token.jsx
+++ b/projects/demo-components/src/access-token.jsx
@@ -1,4 +1,3 @@
-const accessToken =
-  'pk.eyJ1IjoibGFicy1zYW5kYm94IiwiYSI6ImNrMTZuanRmZDA2eGQzYmxqZTlnd21qY3EifQ.Q7DM5HqE5QJzDEnCx8BGFw'
+const accessToken = import.meta.env.VITE_YOUR_MAPBOX_ACCESS_TOKEN
 
 export default accessToken

--- a/projects/demo-components/src/fullscreen-map-layout.jsx
+++ b/projects/demo-components/src/fullscreen-map-layout.jsx
@@ -5,7 +5,7 @@ const FullscreenMapLayout = ({
   headerProps,
   mapComponent,
   children,
-  sidebarSize = 'w320'
+  sidebarSize = 'w300'
 }) => {
   return (
     <div
@@ -35,7 +35,8 @@ const FullscreenMapLayout = ({
 FullscreenMapLayout.propTypes = {
   children: PropTypes.node,
   headerProps: PropTypes.object,
-  mapComponent: PropTypes.node
+  mapComponent: PropTypes.node,
+  sidebarSize: PropTypes.string
 }
 
 export default FullscreenMapLayout

--- a/projects/demo-components/src/map.jsx
+++ b/projects/demo-components/src/map.jsx
@@ -1,118 +1,117 @@
 import PropTypes from 'prop-types'
-import React, { useRef, useEffect } from 'react'
+import React, { useRef, useEffect, forwardRef } from 'react'
 import mapboxgl from 'mapbox-gl'
 import mapboxGeocoder from '@mapbox/mapbox-gl-geocoder'
 
 import 'mapbox-gl/dist/mapbox-gl.css'
 import '@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.css'
-import accessToken from './access-token'
 
-mapboxgl.accessToken = accessToken
+mapboxgl.accessToken = import.meta.env.VITE_YOUR_MAPBOX_ACCESS_TOKEN
 
-const Map = (
-  {
-    center = [0, 0],
-    zoom = 2,
-    style = 'mapbox://styles/mapbox/streets-v12',
-    addGeocoder = false,
-    addNavigationControl = true,
-    onMapLoad,
-    onMapRender,
-    onMapDrag,
-    onMapZoom,
-    onMapRotate,
-    onMapPitch,
-    onMapMove,
-    onMapMoveend,
-    onMapClick,
-    geocoderRef,
-    accessToken,
-    projection = 'globe',
-    hash = false,
-    children
-  },
-  ref
-) => {
-  const mapContainer = useRef(null)
-
-  let mapRef = ref
-
-  if (!mapRef) {
-    mapRef = useRef(null)
-  }
-
-  useEffect(() => {
-    if (mapRef.current) {
-      //debugger;
-      if (onMapRender) {
-        mapRef.current.on('load', onMapRender)
-      }
-      return //initialize map once
-    }
-    const map = (mapRef.current = new mapboxgl.Map({
-      container: mapContainer.current,
-      style,
-      center,
-      zoom,
-      projection,
+const Map = forwardRef(
+  (
+    {
+      center = [0, 0],
+      zoom = 2,
+      style = 'mapbox://styles/mapbox/streets-v12',
+      addGeocoder = false,
+      addNavigationControl = true,
+      onMapLoad,
+      onMapRender,
+      onMapDrag,
+      onMapZoom,
+      onMapRotate,
+      onMapPitch,
+      onMapMove,
+      onMapMoveend,
+      onMapClick,
+      geocoderRef,
       accessToken,
-      hash
-    }))
+      projection = 'globe',
+      hash = false,
+      children
+    },
+    ref
+  ) => {
+    const mapContainer = useRef(null)
+    const internalRef = useRef(null)
+    const mapRef = ref || internalRef
 
-    if (addGeocoder) {
-      const geocoder = new mapboxGeocoder({
-        accessToken: mapboxgl.accessToken,
-        mapboxgl: mapboxgl
-      })
-      map.addControl(geocoder)
-
-      if (geocoderRef) {
-        geocoderRef.current = geocoder
+    useEffect(() => {
+      if (mapRef.current) {
+        //debugger;
+        if (onMapRender) {
+          mapRef.current.on('load', onMapRender)
+        }
+        return //initialize map once
       }
-    }
+      const map = (mapRef.current = new mapboxgl.Map({
+        container: mapContainer.current,
+        style,
+        center,
+        zoom,
+        projection,
+        accessToken,
+        hash
+      }))
 
-    if (addNavigationControl) {
-      map.addControl(new mapboxgl.NavigationControl())
-    }
+      if (addGeocoder) {
+        const geocoder = new mapboxGeocoder({
+          accessToken: mapboxgl.accessToken,
+          mapboxgl: mapboxgl
+        })
+        map.addControl(geocoder)
 
-    if (onMapLoad) {
-      map.on('load', onMapLoad)
-    }
+        if (geocoderRef) {
+          geocoderRef.current = geocoder
+        }
+      }
 
-    if (onMapDrag) {
-      map.on('drag', onMapDrag)
-    }
+      if (addNavigationControl) {
+        map.addControl(new mapboxgl.NavigationControl())
+      }
 
-    if (onMapZoom) {
-      map.on('zoom', onMapZoom)
-    }
+      if (onMapLoad) {
+        map.on('load', onMapLoad)
+      }
 
-    if (onMapRotate) {
-      map.on('rotate', onMapRotate)
-    }
+      if (onMapDrag) {
+        map.on('drag', onMapDrag)
+      }
 
-    if (onMapPitch) {
-      map.on('pitch', onMapPitch)
-    }
+      if (onMapZoom) {
+        map.on('zoom', onMapZoom)
+      }
 
-    if (onMapMoveend) {
-      map.on('moveend', onMapMoveend)
-    }
+      if (onMapRotate) {
+        map.on('rotate', onMapRotate)
+      }
 
-    if (onMapMove) {
-      map.on('move', onMapMove)
-    }
+      if (onMapPitch) {
+        map.on('pitch', onMapPitch)
+      }
 
-    if (onMapClick) {
-      map.on('click', onMapClick)
-    }
-  })
-  return (
-    <div ref={mapContainer} className='map-container h-full'>
-      {children}
-    </div>
-  )
-}
+      if (onMapMoveend) {
+        map.on('moveend', onMapMoveend)
+      }
+
+      if (onMapMove) {
+        map.on('move', onMapMove)
+      }
+
+      if (onMapClick) {
+        map.on('click', onMapClick)
+      }
+    })
+    return (
+      <div ref={mapContainer} className='map-container h-full'>
+        {children}
+      </div>
+    )
+  }
+)
+
+Map.displayName = 'Map'
 
 Map.propTypes = {
   accessToken: PropTypes.string,

--- a/projects/demo-components/src/map.jsx
+++ b/projects/demo-components/src/map.jsx
@@ -1,117 +1,120 @@
 import PropTypes from 'prop-types'
-import React, { useRef, useEffect, forwardRef } from 'react'
+import React, { useRef, useEffect } from 'react'
 import mapboxgl from 'mapbox-gl'
 import mapboxGeocoder from '@mapbox/mapbox-gl-geocoder'
 
 import 'mapbox-gl/dist/mapbox-gl.css'
 import '@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.css'
+import accessToken from './access-token'
 
-mapboxgl.accessToken = import.meta.env.VITE_YOUR_MAPBOX_ACCESS_TOKEN
+mapboxgl.accessToken = accessToken
 
-const Map = forwardRef(
-  (
-    {
-      center = [0, 0],
-      zoom = 2,
-      style = 'mapbox://styles/mapbox/streets-v12',
-      addGeocoder = false,
-      addNavigationControl = true,
-      onMapLoad,
-      onMapRender,
-      onMapDrag,
-      onMapZoom,
-      onMapRotate,
-      onMapPitch,
-      onMapMove,
-      onMapMoveend,
-      onMapClick,
-      geocoderRef,
-      accessToken,
-      projection = 'globe',
-      hash = false,
-      children
-    },
-    ref
-  ) => {
-    const mapContainer = useRef(null)
-    const internalRef = useRef(null)
-    const mapRef = ref || internalRef
+const Map = (
+  {
+    center = [0, 0],
+    zoom = 2,
+    style = 'mapbox://styles/mapbox/streets-v12',
+    addGeocoder = false,
+    addNavigationControl = true,
+    onMapLoad,
+    onMapRender,
+    onMapDrag,
+    onMapZoom,
+    onMapRotate,
+    onMapPitch,
+    onMapMove,
+    onMapMoveend,
+    onMapClick,
+    geocoderRef,
+    accessToken,
+    projection = 'globe',
+    hash = false,
+    children
+  },
+  ref
+) => {
+  const mapContainer = useRef(null)
 
-    useEffect(() => {
-      if (mapRef.current) {
-        //debugger;
-        if (onMapRender) {
-          mapRef.current.on('load', onMapRender)
-        }
-        return //initialize map once
-      }
-      const map = (mapRef.current = new mapboxgl.Map({
-        container: mapContainer.current,
-        style,
-        center,
-        zoom,
-        projection,
-        accessToken,
-        hash
-      }))
+  let mapRef = ref
 
-      if (addGeocoder) {
-        const geocoder = new mapboxGeocoder({
-          accessToken: mapboxgl.accessToken,
-          mapboxgl: mapboxgl
-        })
-        map.addControl(geocoder)
-
-        if (geocoderRef) {
-          geocoderRef.current = geocoder
-        }
-      }
-
-      if (addNavigationControl) {
-        map.addControl(new mapboxgl.NavigationControl())
-      }
-
-      if (onMapLoad) {
-        map.on('load', onMapLoad)
-      }
-
-      if (onMapDrag) {
-        map.on('drag', onMapDrag)
-      }
-
-      if (onMapZoom) {
-        map.on('zoom', onMapZoom)
-      }
-
-      if (onMapRotate) {
-        map.on('rotate', onMapRotate)
-      }
-
-      if (onMapPitch) {
-        map.on('pitch', onMapPitch)
-      }
-
-      if (onMapMoveend) {
-        map.on('moveend', onMapMoveend)
-      }
-
-      if (onMapMove) {
-        map.on('move', onMapMove)
-      }
-
-      if (onMapClick) {
-        map.on('click', onMapClick)
-      }
-    })
-    return (
-      <div ref={mapContainer} className='map-container h-full'>
-        {children}
-      </div>
-    )
+  /* eslint-disable react-hooks/rules-of-hooks */
+  if (!mapRef) {
+    mapRef = useRef(null)
   }
-)
+  /* eslint-enable react-hooks/rules-of-hooks */
 
-Map.displayName = 'Map'
+  useEffect(() => {
+    if (mapRef.current) {
+      //debugger;
+      if (onMapRender) {
+        mapRef.current.on('load', onMapRender)
+      }
+      return //initialize map once
+    }
+    const map = (mapRef.current = new mapboxgl.Map({
+      container: mapContainer.current,
+      style,
+      center,
+      zoom,
+      projection,
+      accessToken,
+      hash
+    }))
+
+    if (addGeocoder) {
+      const geocoder = new mapboxGeocoder({
+        accessToken: mapboxgl.accessToken,
+        mapboxgl: mapboxgl
+      })
+      map.addControl(geocoder)
+
+      if (geocoderRef) {
+        geocoderRef.current = geocoder
+      }
+    }
+
+    if (addNavigationControl) {
+      map.addControl(new mapboxgl.NavigationControl())
+    }
+
+    if (onMapLoad) {
+      map.on('load', onMapLoad)
+    }
+
+    if (onMapDrag) {
+      map.on('drag', onMapDrag)
+    }
+
+    if (onMapZoom) {
+      map.on('zoom', onMapZoom)
+    }
+
+    if (onMapRotate) {
+      map.on('rotate', onMapRotate)
+    }
+
+    if (onMapPitch) {
+      map.on('pitch', onMapPitch)
+    }
+
+    if (onMapMoveend) {
+      map.on('moveend', onMapMoveend)
+    }
+
+    if (onMapMove) {
+      map.on('move', onMapMove)
+    }
+
+    if (onMapClick) {
+      map.on('click', onMapClick)
+    }
+  })
+  return (
+    <div ref={mapContainer} className='map-container h-full'>
+      {children}
+    </div>
+  )
+}
 
 Map.propTypes = {
   accessToken: PropTypes.string,

--- a/projects/demo-realestate/src/Map/index.jsx
+++ b/projects/demo-realestate/src/Map/index.jsx
@@ -1,15 +1,15 @@
 import PropTypes from 'prop-types'
 import { useRef, useEffect, useState } from 'react'
 import mapboxgl from 'mapbox-gl'
-
 import Marker from '../Marker'
 import Card from '../Card'
 
 import 'mapbox-gl/dist/mapbox-gl.css'
 import '@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.css'
 
+// This demo imports accessToken from your .env file and it's exported for use in App.jsx by SearchBox. To use this demo rename your .env.sample file to .env and add your Mapbox access token.
 export const accessToken = (mapboxgl.accessToken =
-  'pk.eyJ1IjoibGFicy1zYW5kYm94IiwiYSI6ImNrMTZuanRmZDA2eGQzYmxqZTlnd21qY3EifQ.Q7DM5HqE5QJzDEnCx8BGFw')
+  import.meta.env.VITE_YOUR_MAPBOX_ACCESS_TOKEN)
 
 const Map = ({ data, onLoad, onFeatureClick }) => {
   const mapContainer = useRef(null)

--- a/projects/demo-realestate/vite.config.js
+++ b/projects/demo-realestate/vite.config.js
@@ -2,5 +2,6 @@ import react from '@vitejs/plugin-react'
 
 export default {
   plugins: [react()],
-  base: '/demo-realestate'
+  base: '/demo-realestate',
+  envDir: '../'
 }

--- a/projects/demo-store-locator/src/Map/index.jsx
+++ b/projects/demo-store-locator/src/Map/index.jsx
@@ -13,7 +13,6 @@ import mapboxgl from 'mapbox-gl'
 import Marker from '../Marker'
 import { AppContext } from '../Context/AppContext'
 import { addUserLocationPulse } from './pulse'
-import { accessToken } from 'mapbox-demo-components'
 
 import 'mapbox-gl/dist/mapbox-gl.css'
 import '@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.css'
@@ -34,11 +33,10 @@ const Map = ({ onLoad }) => {
   let mapRef = useRef(null)
   const pulseRef = useRef(null)
 
-  // This demo imports accessToken from  `demo-components/accessToken`, to use this project
-  // for your purposes, replace `accessToken` below with your own Access Token available
-  // at (https://account.mapbox.com/) - This token is also used in SearchBoxWrapper
+  // This demo imports accessToken from your .env file, to use this project
+  // for your purposes, rename the .env.example file to .env and add your Mapbox access token.
 
-  mapboxgl.accessToken = accessToken
+  mapboxgl.accessToken = import.meta.env.VITE_YOUR_MAPBOX_ACCESS_TOKEN
 
   useEffect(() => {
     if (mapRef.current) return // map already initialized

--- a/projects/demo-store-locator/src/SearchBoxWrapper.jsx
+++ b/projects/demo-store-locator/src/SearchBoxWrapper.jsx
@@ -3,13 +3,16 @@
 
 'use client'
 
-import React, { useContext } from 'react'
+import { useContext } from 'react'
 import { SearchBox } from '@mapbox/search-js-react'
 import mapboxgl from 'mapbox-gl'
-import { accessToken } from 'mapbox-demo-components'
 import { AppContext } from './Context/AppContext'
+import PropTypes from 'prop-types'
 
 const SearchBoxWrapper = ({ mapInstanceRef }) => {
+  // Imported access token from your .env file
+  const accessToken = import.meta.env.VITE_YOUR_MAPBOX_ACCESS_TOKEN
+
   const {
     searchValue,
     setSearchValue,
@@ -72,3 +75,7 @@ const SearchBoxWrapper = ({ mapInstanceRef }) => {
 }
 
 export default SearchBoxWrapper
+
+SearchBoxWrapper.propTypes = {
+  mapInstanceRef: PropTypes.object
+}

--- a/projects/demo-store-locator/vite.config.js
+++ b/projects/demo-store-locator/vite.config.js
@@ -2,5 +2,6 @@ import react from '@vitejs/plugin-react'
 
 export default {
   plugins: [react()],
-  base: '/demo-store-locator'
+  base: '/demo-store-locator',
+  envDir: '../'
 }

--- a/projects/dxf2geojson/index.html
+++ b/projects/dxf2geojson/index.html
@@ -12,6 +12,9 @@
     rel="stylesheet"
   />
 
+  <!-- Add segment tracking for tool usage -->
+  <script src="https://docs.mapbox.com/analytics.min.js"></script>
+
   <script type="text/javascript">
     if (window.location.hostname === 'www.mapbox.com') {
       !(function () {

--- a/projects/dxf2geojson/vite.config.js
+++ b/projects/dxf2geojson/vite.config.js
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
-  base: '/dxf2geojson'
+  base: '/dxf2geojson',
+  envDir: '../'
 })

--- a/projects/isochrone-intersect/index.html
+++ b/projects/isochrone-intersect/index.html
@@ -13,6 +13,8 @@
       content="Use the Mapbox isochrone API to find an optimal meeting spot between two locations"
     />
     <title>Isochrone Intersect | Mapbox Spatial Developer Tools</title>
+    <!-- Add segment tracking for tool usage -->
+    <script src="https://docs.mapbox.com/analytics.min.js"></script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/projects/isochrone-intersect/src/util.jsx
+++ b/projects/isochrone-intersect/src/util.jsx
@@ -5,7 +5,7 @@ import tCenter from '@turf/center'
 import tPointsWithinPolygon from '@turf/points-within-polygon'
 import tArea from '@turf/area'
 
-import { accessToken } from 'mapbox-demo-components'
+const accessToken = import.meta.env.VITE_YOUR_MAPBOX_ACCESS_TOKEN
 
 const urlBase = 'https://api.mapbox.com/isochrone/v1/mapbox/'
 

--- a/projects/isochrone-intersect/vite.config.js
+++ b/projects/isochrone-intersect/vite.config.js
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
-  base: '/isochrone-intersect'
+  base: '/isochrone-intersect',
+  envDir: '../'
 })

--- a/projects/location-helper/vite.config.js
+++ b/projects/location-helper/vite.config.js
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
-  base: '/location-helper'
+  base: '/location-helper',
+  envDir: '../'
 })

--- a/projects/port-geofencing/index.html
+++ b/projects/port-geofencing/index.html
@@ -12,6 +12,8 @@
       name="Port Geofencing"
       content="Explore vector and raster tile addresses and quadkeys."
     />
+    <!-- Add segment tracking for tool usage -->
+    <script src="https://docs.mapbox.com/analytics.min.js"></script>
     <style>
       body {
         margin: 0;

--- a/projects/port-geofencing/vite.config.js
+++ b/projects/port-geofencing/vite.config.js
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
-  base: '/port-geofencing'
+  base: '/port-geofencing',
+  envDir: '../'
 })

--- a/projects/storytelling/vite.config.js
+++ b/projects/storytelling/vite.config.js
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
-  base: '/storytelling'
+  base: '/storytelling',
+  envDir: '../'
 })

--- a/projects/what-the-tile/index.html
+++ b/projects/what-the-tile/index.html
@@ -12,6 +12,8 @@
       name="what the tile"
       content="Explore vector and raster tile addresses and quadkeys."
     />
+    <!-- Add segment tracking for tool usage -->
+    <script src="https://docs.mapbox.com/analytics.min.js"></script>
     <style>
       .fixed.top.left.right.bottom.flex.flex--center-main.flex--center-cross.bg-darken50 {
         display: none !important;

--- a/projects/what-the-tile/vite.config.js
+++ b/projects/what-the-tile/vite.config.js
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
-  base: '/what-the-tile'
+  base: '/what-the-tile',
+  envDir: '../'
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -7595,6 +7595,7 @@ stop-iteration-iterator@^1.0.0:
     internal-slot "^1.1.0"
 
 "string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==


### PR DESCRIPTION
This PR removes all hardcoded tokens in the shared components or consuming projects.  In place of those hardcoded tokens it now uses [Vite's env vars](https://vite.dev/guide/env-and-mode#env-variables) and adds a `.env.sample` and a section in the `Readme.md` on how to add your own public token to this workspace.  

Components now consume this token across all projects.

In addition each projects `vite.config.js` required adding a `envDir` parameter to tell the project to look at the env file inside the `/projects/` directory.  

Other small fixes include adding tracking to existing projects which didn't have it. And a correction of a bad class in the `fullscreen-map-layout.jsx`. `w320` is not a proper assembly classname.  

## Testing

Pull down this branch, follow the directions in the Readme to setup your own local `.env` file.  `cd` into each project and `npm run dev` to ensure all projects are working as expected.  


