### PR TITLE
Updated the style to use examples account style

### DIFF
--- a/projects/storytelling/src/config.js
+++ b/projects/storytelling/src/config.js
@@ -1,6 +1,6 @@
 // eslint-disable-next-line
 export const config = {
-  style: 'mapbox://styles/labs-sandbox/cle6ecgky007t01lja19luc67',
+  style: 'mapbox://styles/examples/cmlqpbccj000e01qk91p3hzve',
   accessToken: import.meta.env.VITE_YOUR_MAPBOX_ACCESS_TOKEN,
   showMarkers: false,
   theme: 'dark',


### PR DESCRIPTION
In an internal clean up of accounts, the storytelling style which was owned by the `labs-sandbox` user was migrated to the `examples` accounts (owned by the documentation team).  The style URL is updated accordingly in the storytelling project.

