### PR TITLE
Update demo feature tour mobile controls

### DIFF
--- a/projects/demo-feature-tour/README.md
+++ b/projects/demo-feature-tour/README.md
@@ -1,28 +1,42 @@
-# use-mapbox-gl-js-with-react
+# Demo Feature Tour
 
-This is supporting code for the Mapbox tutorial [Use Mapbox GL JS in an React app](https://docs.mapbox.com/help/tutorials/use-mapbox-gl-js-with-react/).
+An interactive product demo built with React and [Mapbox GL JS](https://docs.mapbox.com/mapbox-gl-js/guides/) that tours a single map through several Mapbox capabilities. Selecting a use case from the panel flies the camera to a new scene and reconfigures the map to demonstrate that feature.
 
-## Overview
+## Use cases demonstrated
 
-This tutorial walks through how to setup [Mapbox GL JS](https://docs.mapbox.com/mapbox-gl-js/) in an [React](https://react.dev) project.  
+- **Globe View** — rotating 3D globe with the Mapbox Standard style
+- **3D Basemap** — buildings, landmarks, and trees
+- **Markers** — custom pins with popups
+- **Data Overlay (2D)** — live seismic event heatmap
+- **Wind Speed** — global particle-based wind animation
+- **Navigation** — turn-by-turn route guidance
+- **Asset Tracking** — fleet locations and delivery isochrones
+- **Terrain** — 3D landscape with elevation
 
+Each scene lives in its own module under `src/scenes/`, and is wired up in `src/App.jsx`.
 
-You'll learn how to:
-- Setup a Vite JS app to use React
-- How to install Mapbox GL JS and its dependencies.
-- Use Mapbox GL JS to render a full screen map.
-- How to add a toolbar which displays map state like `longitude`, `latitude`, and `zoom` level and is updated as the map is interacted with (showing the map to app data flow).
-- How to create a UI button to reset the map to its original view (showing the app to map data flow).
+Products used:
+- [Mapbox GL JS](https://docs.mapbox.com/mapbox-gl-js/guides/) — map rendering, Standard style config properties, terrain, custom layers/sources
+- [Isochrone API](https://docs.mapbox.com/api/navigation/isochrone/) — drive-time contours in the Asset Tracking scene
 
+## Query parameters
+
+- `cooperativeGestures=true` — enables [cooperative gestures](https://docs.mapbox.com/mapbox-gl-js/api/map/#map-parameters) so the map requires a modifier key (or two-finger touch) to pan/zoom instead of capturing all scroll/touch input. Off by default; intended for embedding the demo in an iframe alongside scrollable page content.
 
 ## Prerequisites
 
 - Node v18.20 or higher
-- npm
+- Yarn
 
 ## How to run
 
-- Clone this repository and navigate to this directory
-- Install dependencies with `npm install`
-- Replace `YOUR_MAPBOX_ACCESS_TOKEN` in `src/App.jsx` with an access token from your [Mapbox account](https://console.mapbox.com/).
-- Run the development server with `npm run dev` and open the app in your browser at [http://localhost:5173](http://localhost:5173).
+This project lives in a Yarn workspaces monorepo, so dependencies are installed from the repo root.
+
+- Clone this repository
+- Install dependencies at the top level of the monorepo: `yarn`
+- Copy `projects/.env.sample` to `projects/.env` and add your Mapbox access token:
+  ```
+  VITE_YOUR_MAPBOX_ACCESS_TOKEN=your_access_token_here
+  ```
+  You can get a token from your [Mapbox account](https://console.mapbox.com/).
+- Run the development server: `cd projects/demo-feature-tour && yarn dev`, then open [http://localhost:5173](http://localhost:5173).

--- a/projects/demo-feature-tour/src/App.css
+++ b/projects/demo-feature-tour/src/App.css
@@ -1087,7 +1087,7 @@
   align-items: stretch;
   gap: 8px;
   min-width: 0;
-  padding: 10px 12px;
+  padding: 10px 13px 11px;
   position: relative;
 }
 
@@ -1273,6 +1273,7 @@
 .tb-divider {
   width: 1px;
   align-self: stretch;
+  margin: 10px 0;
   background: rgba(255, 255, 255, 0.07);
   flex-shrink: 0;
 }

--- a/projects/demo-feature-tour/src/App.css
+++ b/projects/demo-feature-tour/src/App.css
@@ -1070,70 +1070,93 @@
   left: 50%;
   transform: translateX(-50%);
   z-index: 20;
-  align-items: center;
-  gap: 2px;
-  padding: 5px;
+  align-items: stretch;
+  gap: 0;
   background: rgba(10, 10, 14, 0.9);
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
   border: 1px solid rgba(255, 255, 255, 0.07);
-  border-radius: 10px;
+  border-radius: 8px;
   box-shadow: 0 8px 40px rgba(0, 0, 0, 0.45);
   max-width: calc(100vw - 32px);
 }
 
-/* Scene — primary control */
-.tb-scene-dropdown {
+.tb-field {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 8px;
+  min-width: 0;
+  padding: 10px 12px;
+  position: relative;
+}
+
+.tb-field-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #707c8e;
+  line-height: 1;
+  white-space: nowrap;
+  text-align: left;
+  padding: 0 2px;
+}
+
+.tb-scene-field {
   flex: 1 0 auto;
 }
 
+/* Scene — primary control */
+.tb-scene-dropdown {
+  width: 100%;
+}
+
 .tb-scene-dropdown .tb-dropdown-btn {
-  font-size: 14px;
-  font-weight: 600;
-  color: #e8ecf2;
-  padding: 7px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 9px 12px;
 }
 
 .tb-scene-dropdown .tb-scene-icon svg {
-  width: 17px;
-  height: 17px;
+  width: 20px;
+  height: 20px;
 }
 
 .tb-scene-label {
-  color: #e8ecf2;
-  font-weight: 600;
-  font-size: 14px;
-}
-
-.tb-secondary {
-  display: flex;
-  align-items: center;
+  font-weight: 500;
+  font-size: 13px;
 }
 
 .tb-dropdown {
-  position: relative;
+  width: 100%;
 }
 
 .tb-dropdown-btn {
   display: flex;
   align-items: center;
-  gap: 7px;
-  padding: 7px 12px;
-  background: transparent;
-  border: none;
-  border-radius: 7px;
+  justify-content: flex-start;
+  gap: 8px;
+  width: 100%;
+  min-height: 40px;
+  box-sizing: border-box;
+  padding: 9px 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 4px;
   cursor: pointer;
-  color: #bbc2ce;
+  color: #fff;
   font-family: inherit;
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 500;
-  transition: color 0.15s, background 0.15s;
+  transition: background 0.25s, color 0.25s, border-color 0.25s;
   white-space: nowrap;
 }
 
 .tb-dropdown-btn:hover {
-  background: rgba(255, 255, 255, 0.05);
+  background: rgba(255, 255, 255, 0.06);
   color: #fff;
+  border-color: rgba(255, 255, 255, 0.12);
 }
 
 .tb-scene-icon {
@@ -1142,8 +1165,8 @@
 }
 
 .tb-scene-icon svg {
-  width: 15px;
-  height: 15px;
+  width: 20px;
+  height: 20px;
   stroke: currentColor;
 }
 
@@ -1154,61 +1177,59 @@
 }
 
 .tb-preset-icon svg {
-  width: 14px;
-  height: 14px;
+  width: 20px;
+  height: 20px;
   stroke: currentColor;
 }
 
 .tb-swatch {
   display: flex;
+  align-items: center;
   gap: 2px;
   flex-shrink: 0;
+  height: 20px;
 }
 
 .tb-swatch-dot {
-  width: 8px;
-  height: 8px;
+  width: 10px;
+  height: 10px;
   border-radius: 50%;
   border: 1px solid rgba(0, 0, 0, 0.2);
 }
 
-.tb-meta-label {
-  font-size: 11px;
-  color: #566171;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-}
-
 .tb-value {
-  color: #bbc2ce;
   font-weight: 500;
+  font-size: 13px;
 }
 
 .tb-chevron {
   width: 13px;
   height: 13px;
   flex-shrink: 0;
-  color: #566171;
+  margin-left: auto;
+  color: #707c8e;
+  transform: translateY(1px);
   transition: transform 0.15s;
 }
 
 .tb-chevron.open {
-  transform: rotate(180deg);
+  transform: translateY(1px) rotate(180deg);
 }
 
 .tb-dropdown-menu {
   position: absolute;
   top: calc(100% + 6px);
-  left: 50%;
-  transform: translateX(-50%);
+  left: 0;
+  min-width: 100%;
+  width: max-content;
+  max-width: calc(100vw - 32px);
   background: rgba(10, 10, 14, 0.96);
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
   border: 1px solid rgba(255, 255, 255, 0.07);
-  border-radius: 10px;
+  border-radius: 8px;
   box-shadow: 0 8px 40px rgba(0, 0, 0, 0.5);
-  padding: 6px;
-  min-width: 150px;
+  padding: 12px;
   z-index: 100;
   display: flex;
   flex-direction: column;
@@ -1220,7 +1241,7 @@
   align-items: center;
   gap: 10px;
   width: 100%;
-  padding: 8px 10px;
+  padding: 8px 12px;
   background: transparent;
   border: 1px solid transparent;
   border-radius: 7px;
@@ -1230,6 +1251,7 @@
   font-size: 13px;
   font-weight: 500;
   text-align: left;
+  white-space: nowrap;
   transition: background 0.15s, color 0.15s;
 }
 
@@ -1250,10 +1272,9 @@
 
 .tb-divider {
   width: 1px;
-  height: 20px;
+  align-self: stretch;
   background: rgba(255, 255, 255, 0.07);
   flex-shrink: 0;
-  margin: 0 2px;
 }
 
 .tb-toggles {
@@ -1290,13 +1311,7 @@
 
 /* ─── Responsive ────────────────────────────────────────────────────────────── */
 
-@media (min-width: 900px) {
-  .top-bar {
-    display: none;
-  }
-}
-
-@media (max-width: 899px) {
+@media (max-width: 991px) {
   .use-case-panel,
   .map-controls {
     display: none;
@@ -1306,82 +1321,41 @@
   }
 }
 
-@media (max-height: 640px) {
-  .scene-info {
-    display: none;
-  }
-  .control-section:has(.toggle-list) {
-    display: none;
-  }
-}
-
 @media (max-width: 640px) {
-  .use-case-panel {
-    top: 12px;
-    left: 12px;
-    width: 200px;
-    max-width: none;
-  }
-
-  .scene-info {
-    display: none;
-  }
-
-  .map-controls {
-    display: none;
-  }
-
-  .uc-desc {
-    display: none;
-  }
-
   .nav-card {
     bottom: 16px;
     left: 12px;
     right: 12px;
     width: auto;
   }
-
-  /* On mobile, collapse preset/theme labels — just icons */
-  .preset-label,
-  .pill-label {
-    display: none;
-  }
-
-  .preset-btn {
-    justify-content: center;
-    padding: 8px;
-  }
-
-  .control-pill {
-    justify-content: center;
-    padding: 8px;
-    border-radius: 50%;
-    width: 38px;
-    height: 38px;
-  }
-
-  .pill-toggle {
-    display: none;
-  }
 }
 
-@media (max-width: 491px) {
-  .use-case-panel {
-    width: auto;
-    border-radius: 8px;
+@media (max-width: 600px) {
+  .top-bar {
+    flex-direction: column;
+    top: 16px;
+    left: 16px;
+    right: auto;
+    transform: none;
+    width: max-content;
+    max-width: calc(100vw - 32px);
+    padding: 12px;
+    gap: 14px;
   }
-  .use-case-list {
-    padding: 8px;
+
+  .tb-field {
+    padding: 0;
   }
-  .use-case-btn {
-    padding: 8px;
-    border-radius: 4px;
+
+  .tb-scene-field {
+    flex: none;
   }
-  .panel-heading {
+
+  .tb-divider {
     display: none;
   }
-  .uc-text {
-    display: none;
+
+  .tb-dropdown-menu {
+    padding: 10px;
   }
 }

--- a/projects/demo-feature-tour/src/App.jsx
+++ b/projects/demo-feature-tour/src/App.jsx
@@ -52,7 +52,8 @@ export default function App() {
       style: 'mapbox://styles/mapbox/standard',
       bounds: GLOBE_BOUNDS,
       pitch: 0,
-      bearing: 0
+      bearing: 0,
+      cooperativeGestures: true
     })
 
     const startCameraRotation = () => {
@@ -246,16 +247,37 @@ export default function App() {
       if (id !== 'terrain') setIsSatellite(false)
 
       switch (id) {
-        case 'buildings':      activate3DBuildings(ctx); break
-        case 'markers':        activateMarkers(ctx); break
-        case 'data-overlay':   activateDataOverlay(ctx); break
-        case 'raster':         activateRaster(ctx); break
-        case 'navigation':     activateNavigation(ctx); break
-        case 'asset-tracking': activateAssetTracking(ctx); break
-        case 'terrain':        activateTerrain(ctx); break
+        case 'buildings':
+          activate3DBuildings(ctx)
+          break
+        case 'markers':
+          activateMarkers(ctx)
+          break
+        case 'data-overlay':
+          activateDataOverlay(ctx)
+          break
+        case 'raster':
+          activateRaster(ctx)
+          break
+        case 'navigation':
+          activateNavigation(ctx)
+          break
+        case 'asset-tracking':
+          activateAssetTracking(ctx)
+          break
+        case 'terrain':
+          activateTerrain(ctx)
+          break
       }
     },
-    [mapLoaded, activeUseCase, cleanup, setLightPreset, setColorTheme, setIsSatellite]
+    [
+      mapLoaded,
+      activeUseCase,
+      cleanup,
+      setLightPreset,
+      setColorTheme,
+      setIsSatellite
+    ]
   )
 
   // ─── Render ────────────────────────────────────────────────────────────────

--- a/projects/demo-feature-tour/src/App.jsx
+++ b/projects/demo-feature-tour/src/App.jsx
@@ -46,14 +46,18 @@ export default function App() {
   // ─── Map Init ──────────────────────────────────────────────────────────────
 
   useEffect(() => {
-    mapboxgl.accessToken = import.meta.env.VITE_YOUR_MAPBOX_ACCESS_TOKEN
+    const cooperativeGestures =
+      new URLSearchParams(window.location.search).get('cooperativeGestures') ===
+      'true'
+
     mapRef.current = new mapboxgl.Map({
+      accessToken: import.meta.env.VITE_YOUR_MAPBOX_ACCESS_TOKEN,
       container: mapContainerRef.current,
       style: 'mapbox://styles/mapbox/standard',
       bounds: GLOBE_BOUNDS,
       pitch: 0,
       bearing: 0,
-      cooperativeGestures: true
+      cooperativeGestures
     })
 
     const startCameraRotation = () => {

--- a/projects/demo-feature-tour/src/components/TopBar.jsx
+++ b/projects/demo-feature-tour/src/components/TopBar.jsx
@@ -96,6 +96,15 @@ const COLOR_THEMES = [
   { id: 'vivid', label: 'Vivid', swatches: ['#FF4D4D', '#4DFF91', '#4D79FF'] }
 ]
 
+function ControlField({ label, className, children }) {
+  return (
+    <div className={`tb-field${className ? ` ${className}` : ''}`}>
+      <span className='tb-field-label'>{label}</span>
+      {children}
+    </div>
+  )
+}
+
 function Dropdown({
   dropdownRef,
   open,
@@ -109,7 +118,10 @@ function Dropdown({
       className={`tb-dropdown${className ? ' ' + className : ''}`}
       ref={dropdownRef}
     >
-      <button className='tb-dropdown-btn' onClick={onToggle}>
+      <button
+        className={`tb-dropdown-btn${open ? ' open' : ''}`}
+        onClick={onToggle}
+      >
         {trigger}
         <svg
           className={`tb-chevron${open ? ' open' : ''}`}
@@ -157,38 +169,38 @@ export default function TopBar({
 
   return (
     <div className='top-bar'>
-      {/* Scene — primary, prominent */}
-      <Dropdown
-        className='tb-scene-dropdown'
-        dropdownRef={sceneRef}
-        open={openMenu === 'scene'}
-        onToggle={() => setOpenMenu((o) => (o === 'scene' ? null : 'scene'))}
-        trigger={
-          <>
-            <span className='tb-scene-icon'>{activeScene?.icon}</span>
-            <span className='tb-scene-label'>{activeScene?.label}</span>
-          </>
-        }
-      >
-        {USE_CASES.map((uc) => (
-          <button
-            key={uc.id}
-            className={`tb-menu-item${activeId === uc.id ? ' active' : ''}`}
-            onClick={() => {
-              onSelect(uc.id)
-              setOpenMenu(null)
-            }}
-          >
-            <span className='tb-scene-icon'>{uc.icon}</span>
-            <span>{uc.label}</span>
-          </button>
-        ))}
-      </Dropdown>
+      <ControlField label='Scenes' className='tb-scene-field'>
+        <Dropdown
+          className='tb-scene-dropdown'
+          dropdownRef={sceneRef}
+          open={openMenu === 'scene'}
+          onToggle={() => setOpenMenu((o) => (o === 'scene' ? null : 'scene'))}
+          trigger={
+            <>
+              <span className='tb-scene-icon'>{activeScene?.icon}</span>
+              <span className='tb-scene-label'>{activeScene?.label}</span>
+            </>
+          }
+        >
+          {USE_CASES.map((uc) => (
+            <button
+              key={uc.id}
+              className={`tb-menu-item${activeId === uc.id ? ' active' : ''}`}
+              onClick={() => {
+                onSelect(uc.id)
+                setOpenMenu(null)
+              }}
+            >
+              <span className='tb-scene-icon'>{uc.icon}</span>
+              <span>{uc.label}</span>
+            </button>
+          ))}
+        </Dropdown>
+      </ControlField>
 
-      {/* Secondary controls — grouped so they wrap together */}
-      <div className='tb-secondary'>
-        <div className='tb-divider' />
+      <div className='tb-divider' />
 
+      <ControlField label='Lighting'>
         <Dropdown
           dropdownRef={lightingRef}
           open={openMenu === 'lighting'}
@@ -197,7 +209,6 @@ export default function TopBar({
           }
           trigger={
             <>
-              <span className='tb-meta-label'>Lighting</span>
               <span className='tb-preset-icon'>{activeLight?.icon}</span>
               <span className='tb-value'>{activeLight?.label}</span>
             </>
@@ -217,14 +228,17 @@ export default function TopBar({
             </button>
           ))}
         </Dropdown>
+      </ControlField>
 
+      <div className='tb-divider' />
+
+      <ControlField label='Color'>
         <Dropdown
           dropdownRef={themeRef}
           open={openMenu === 'theme'}
           onToggle={() => setOpenMenu((o) => (o === 'theme' ? null : 'theme'))}
           trigger={
             <>
-              <span className='tb-meta-label'>Color</span>
               <span className='tb-swatch'>
                 {activeTheme?.swatches.map((c, i) => (
                   <span
@@ -260,7 +274,7 @@ export default function TopBar({
             </button>
           ))}
         </Dropdown>
-      </div>
+      </ControlField>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Enable cooperative gestures for embedded map scroll behavior
- Redesign mobile top bar with labeled control groups and stacked layout at 600px
- Raise desktop/mobile switch to 991px and remove redundant breakpoints
- Refine horizontal top bar spacing with inset dividers

## Test plan
- [ ] Desktop (≥992px): side panels visible, top bar hidden
- [ ] Tablet (601–991px): horizontal top bar with inset dividers
- [ ] Mobile (≤600px): stacked top bar, dividers hidden
- [ ] Cooperative gestures: page scroll works without hijacking map zoom